### PR TITLE
Configure vial security for Svalboard

### DIFF
--- a/keyboards/svalboard/keymaps/vial/config.h
+++ b/keyboards/svalboard/keymaps/vial/config.h
@@ -18,3 +18,7 @@
 #define VIAL_UNLOCK_COMBO_ROWS { 0, 0, 5, 5 }
 #define VIAL_UNLOCK_COMBO_COLS { 2, 5, 2, 5 }
 #endif
+
+// Shorten the unlock timeout (needs mod in `quantum/vial.c`; without
+// it the override doesn't work)
+#define VIAL_UNLOCK_COUNTER_MAX 25

--- a/keyboards/svalboard/keymaps/vial/config.h
+++ b/keyboards/svalboard/keymaps/vial/config.h
@@ -4,13 +4,17 @@
 
 #define VIAL_KEYBOARD_UID {0x1B, 0x18, 0x7D, 0xF2, 0x21, 0xF6, 0x29, 0x48}
 
-// Vial unlock combos
-#ifdef SVALBOARD_UNLOCK_BY_DEEP_PRESS
+// Vial security combos, depending on which unit this is...
+#ifdef INIT_EE_HANDS_RIGHT
+// right thumb lock
+#define VIAL_UNLOCK_COMBO_ROWS { 5, 5 }
+#define VIAL_UNLOCK_COMBO_COLS { 2, 5 }
+#elif INIT_EE_HANDS_LEFT
+// left thumb lock
+#define VIAL_UNLOCK_COMBO_ROWS { 0, 0 }
+#define VIAL_UNLOCK_COMBO_COLS { 2, 5 }
+#else
 // both thumb locks
 #define VIAL_UNLOCK_COMBO_ROWS { 0, 0, 5, 5 }
 #define VIAL_UNLOCK_COMBO_COLS { 2, 5, 2, 5 }
-#else
-// both thumb down, without a lock
-#define VIAL_UNLOCK_COMBO_ROWS { 0, 5 }
-#define VIAL_UNLOCK_COMBO_COLS { 2, 2 }
 #endif

--- a/keyboards/svalboard/keymaps/vial/config.h
+++ b/keyboards/svalboard/keymaps/vial/config.h
@@ -3,3 +3,14 @@
 #pragma once
 
 #define VIAL_KEYBOARD_UID {0x1B, 0x18, 0x7D, 0xF2, 0x21, 0xF6, 0x29, 0x48}
+
+// Vial unlock combos
+#ifdef SVALBOARD_UNLOCK_BY_DEEP_PRESS
+// both thumb locks
+#define VIAL_UNLOCK_COMBO_ROWS { 0, 0, 5, 5 }
+#define VIAL_UNLOCK_COMBO_COLS { 2, 5, 2, 5 }
+#else
+// both thumb down, without a lock
+#define VIAL_UNLOCK_COMBO_ROWS { 0, 5 }
+#define VIAL_UNLOCK_COMBO_COLS { 2, 2 }
+#endif

--- a/keyboards/svalboard/keymaps/vial/rules.mk
+++ b/keyboards/svalboard/keymaps/vial/rules.mk
@@ -1,4 +1,2 @@
 VIA_ENABLE = yes
 VIAL_ENABLE = yes
-#VIAL_INSECURE = yes
-

--- a/keyboards/svalboard/keymaps/vial/rules.mk
+++ b/keyboards/svalboard/keymaps/vial/rules.mk
@@ -1,4 +1,4 @@
 VIA_ENABLE = yes
 VIAL_ENABLE = yes
-VIAL_INSECURE = yes
+#VIAL_INSECURE = yes
 

--- a/quantum/vial.c
+++ b/quantum/vial.c
@@ -24,7 +24,9 @@
 
 #include "vial_ensure_keycode.h"
 
+#ifndef VIAL_UNLOCK_COUNTER_MAX
 #define VIAL_UNLOCK_COUNTER_MAX 50
+#endif
 
 #ifdef VIAL_INSECURE
 #pragma message "Building Vial-enabled firmware in insecure mode."


### PR DESCRIPTION
The unlock is configured per-hand (whichever is master), so both units don't need to be present.

Also, the unlock timeout is halved (which needed a reluctant two-liner mod to `quantum/vial.c`).