### PR TITLE
Enable split watchdog

### DIFF
--- a/keyboards/svalboard/config.h
+++ b/keyboards/svalboard/config.h
@@ -55,3 +55,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define USB_MAX_POWER_CONSUMPTION 500
 #define USB_SUSPEND_WAKEUP_DELAY 500
 #define SELECT_SOFT_SERIAL_RATE {0}
+
+// Avoid slave-slave deadlock due to missing USB_VBUS_PIN.
+//
+// End result of enabling this: when you plug the keyboard to a finnicky USB
+// hub, KVM, or a machine that boots slowly (ECC RAM), the keyboard no longer
+// needs to be reset to come to life.
+#define SPLIT_WATCHDOG_ENABLE


### PR DESCRIPTION
With `SPLIT_USB_DETECT` (and without `SPLIT_WATCHDOG_ENABLE` or `USB_VBUS_PIN` defined), the split code polls for active USB to determine which unit is master (see `split_post_init` in `quantum/split_common/split_util.c`), and defaults to slave.

With the watchdog it resets the MCU after `SPLIT_WATCHDOG_TIMEOUT` unless it got a ping from a master (or became master).

Thus, if the USB only becomes available after a long-ish time (finnicky USB hub, KVM, or a machine that boots slowly (ECC RAM)), enabling the watchdog will make the keyboard automagically work (instead of staying stuck in slave-slave config until manual reset).
