### PR TITLE
keymap/vial: Modifiers work with mouse keys.

### DIFF
--- a/keyboards/svalboard/keymaps/vial/keymap.c
+++ b/keyboards/svalboard/keymaps/vial/keymap.c
@@ -250,6 +250,14 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       case KC_WH_D:
       case KC_WH_R:
       case KC_WH_L:
+      case KC_LSFT:
+      case KC_RSFT:
+      case KC_LCTL:
+      case KC_RCTL:
+      case KC_LALT:
+      case KC_RALT:
+      case KC_LGUI:
+      case KC_RGUI:
 	break;
       default:
 	mouse_mode(false);


### PR DESCRIPTION
This allows left and right:

Shift
Control
Alt
Gui

Now all do not disable mosue keys.

<!---

    If you are submitting a Vial-enabled keymap for a keyboard in QMK:

    - Keymaps will not be accepted with VIAL_INSECURE=yes.
    - Avoid changing keyboard-level code if possible. (ex: switching the encoder pins in info.json)
    - Please name your keymap "vial". Personal keymaps are not accepted at this time.
      - If your Vial keymap only works for a specific keyboard revision, place it under that revision's folder. (ex: keyboards/planck/rev6_drop/keymaps/vial and keyboards/planck/ez/glow/keymaps/vial)

    If you are submitting a new keyboard with keymaps:

    - If you are also submitting this keyboard to QMK, please try to submit mostly the same code to both repos if possible.
    - If you are not submitting this keyboard to QMK, only include "default" and "vial" keymaps. VIA firmware can no longer be built by this repository.

    ------

    For all keyboard and keymap submissions:

    As the submitter, you are ultimately responsible for maintaining the keyboards/keymaps you submit.
    Vial contributors will try to fix compilation issues as updates are made, but are not always familiar with and often can't test specific keymaps/keyboards.

    Vial is decentralized, so inclusion in the vial-qmk repository is optional. Unmaintained keymaps/keyboards which are broken and cannot be fixed without extensive rework or strong familiarity with the hardware may be removed from this repository, with or without warning.

    ------

    For core changes, please explain what you are changing and why.

    Before submitting a PR, delete the entirety of this comment and document your changes.
-->
