### PR TITLE
trackpoint: Disable calibration - Fix the drift.

### DIFF
--- a/keyboards/svalboard/keymaps/vial/keymap.c
+++ b/keyboards/svalboard/keymaps/vial/keymap.c
@@ -47,6 +47,7 @@ enum my_keycodes {
   SV_RIGHT_DPI_DEC,
   SV_LEFT_SCROLL_TOGGLE,
   SV_RIGHT_SCROLL_TOGGLE,
+  SV_RECALIBRATE_POINTER,
   KC_NORMAL_HOLD = SAFE_RANGE,
   KC_FUNC_HOLD,
 };
@@ -163,11 +164,11 @@ const uint16_t PROGMEM keymaps[NUM_LAYERS][MATRIX_ROWS][MATRIX_COLS] = {
         /*R1*/ KC_TRNS,        KC_TRNS,       KC_TRNS,       KC_BTN1,       KC_TRNS,
         /*R2*/ KC_TRNS,        KC_TRNS,       KC_TRNS,       KC_BTN3,       KC_TRNS,
         /*R3*/ KC_TRNS,        KC_TRNS,       KC_TRNS,       KC_BTN2,       KC_TRNS,
-        /*R4*/ KC_TRNS,        KC_TRNS,       KC_TRNS,       KC_TRNS,       KC_TRNS,
+        /*R4*/ SV_RECALIBRATE_POINTER,        KC_TRNS,       KC_TRNS,       KC_TRNS,       KC_TRNS,
         /*L1*/ KC_TRNS,        KC_TRNS,       KC_TRNS,       KC_BTN1,        KC_TRNS,
         /*L2*/ KC_TRNS,        KC_TRNS,       KC_TRNS,       KC_BTN3,        KC_TRNS,
         /*L3*/ KC_TRNS,        KC_TRNS,       KC_TRNS,       KC_BTN2,        KC_TRNS,
-        /*L4*/ KC_TRNS,        KC_TRNS,       KC_TRNS,       KC_TRNS,       KC_TRNS,
+        /*L4*/ SV_RECALIBRATE_POINTER,        KC_TRNS,       KC_TRNS,       KC_TRNS,       KC_TRNS,
         /*RT*/ KC_TRNS,        KC_TRNS,       KC_TRNS,       KC_TRNS,       KC_TRNS,   KC_TRNS,
         /*LT*/ KC_TRNS,        KC_TRNS,       KC_TRNS,       KC_TRNS,       KC_TRNS,   KC_TRNS
         )
@@ -284,6 +285,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
            case SV_RIGHT_SCROLL_TOGGLE:
                 global_saved_values.right_scroll = !global_saved_values.right_scroll;
                 write_eeprom_kb();
+                break;
+           case SV_RECALIBRATE_POINTER:
+                recalibrate_pointer();
            default:
                 break;
         }

--- a/keyboards/svalboard/keymaps/vial/keymap.c
+++ b/keyboards/svalboard/keymaps/vial/keymap.c
@@ -259,6 +259,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       case KC_RALT:
       case KC_LGUI:
       case KC_RGUI:
+      case SV_RECALIBRATE_POINTER:
 	break;
       default:
 	mouse_mode(false);

--- a/keyboards/svalboard/keymaps/vial/vial.json
+++ b/keyboards/svalboard/keymaps/vial/vial.json
@@ -35,6 +35,11 @@
         "shortName": "Scroll\nRight\nToggle",
         "title": "Toggle if the right pointer is scroll or pointer.",
         "name": "SV_RIGHT_SCROLL_TOGGLE"
+      },
+      {
+        "shortName": "Fix\nDrift",
+        "title": "Reset the calibration of the pointing device",
+        "name": "SV_RECALIBRATE_POINTER"
       }
     ],
     "layouts": {

--- a/keyboards/svalboard/svalboard.h
+++ b/keyboards/svalboard/svalboard.h
@@ -38,3 +38,4 @@ void decrease_right_dpi(void);
 void set_left_dpi(uint8_t index);
 void set_right_dpi(uint8_t index);
 void write_eeprom_kb(void);
+void recalibrate_pointer(void);


### PR DESCRIPTION
This should fix the drift we've been getting, it also adds the calibration instructions we've been give by Sprintek.

Documents the deadzone parameter, but doesn't use it.

<!---

    If you are submitting a Vial-enabled keymap for a keyboard in QMK:

    - Keymaps will not be accepted with VIAL_INSECURE=yes.
    - Avoid changing keyboard-level code if possible. (ex: switching the encoder pins in info.json)
    - Please name your keymap "vial". Personal keymaps are not accepted at this time.
      - If your Vial keymap only works for a specific keyboard revision, place it under that revision's folder. (ex: keyboards/planck/rev6_drop/keymaps/vial and keyboards/planck/ez/glow/keymaps/vial)

    If you are submitting a new keyboard with keymaps:

    - If you are also submitting this keyboard to QMK, please try to submit mostly the same code to both repos if possible.
    - If you are not submitting this keyboard to QMK, only include "default" and "vial" keymaps. VIA firmware can no longer be built by this repository.

    ------

    For all keyboard and keymap submissions:

    As the submitter, you are ultimately responsible for maintaining the keyboards/keymaps you submit.
    Vial contributors will try to fix compilation issues as updates are made, but are not always familiar with and often can't test specific keymaps/keyboards.

    Vial is decentralized, so inclusion in the vial-qmk repository is optional. Unmaintained keymaps/keyboards which are broken and cannot be fixed without extensive rework or strong familiarity with the hardware may be removed from this repository, with or without warning.

    ------

    For core changes, please explain what you are changing and why.

    Before submitting a PR, delete the entirety of this comment and document your changes.
-->
