### PR TITLE
Improve default mousekey feel

### DIFF
--- a/keyboards/svalboard/ballpoint/left/info.json
+++ b/keyboards/svalboard/ballpoint/left/info.json
@@ -27,10 +27,10 @@
       "rows": ["GP8", "GP7", "GP6", "GP5", "GP4"]                                         
   },                                                                                      
   "mousekey": {                                                                           
-      "delay": 150,                                                                       
-      "interval": 60,                                                                     
-      "max_speed": 5,                                                                     
-      "time_to_max": 7                                                                    
+      "delay": 30,                                                                       
+      "move_delta": 1,
+      "max_speed": 15,                                                                    
+      "time_to_max": 40                                                                    
   },                                                                                      
   "processor": "RP2040",                                                                  
   "split": {                                                                              

--- a/keyboards/svalboard/ballpoint/right/info.json
+++ b/keyboards/svalboard/ballpoint/right/info.json
@@ -27,10 +27,10 @@
       "rows": ["GP8", "GP7", "GP6", "GP5", "GP4"]                                         
   },                                                                                      
   "mousekey": {                                                                           
-      "delay": 150,                                                                       
-      "interval": 60,                                                                     
-      "max_speed": 5,                                                                     
-      "time_to_max": 7                                                                    
+      "delay": 30,                                                                       
+      "move_delta": 1,
+      "max_speed": 15,                                                                    
+      "time_to_max": 40                                                                    
   },                                                                                      
   "processor": "RP2040",                                                                  
   "split": {                                                                              

--- a/keyboards/svalboard/info.json
+++ b/keyboards/svalboard/info.json
@@ -27,10 +27,10 @@
       "rows": ["GP8", "GP7", "GP6", "GP5", "GP4"]                                         
   },                                                                                      
   "mousekey": {                                                                           
-      "delay": 150,                                                                       
-      "interval": 60,                                                                     
-      "max_speed": 5,                                                                     
-      "time_to_max": 7                                                                    
+      "delay": 30,                                                                       
+      "move_delta": 1,
+      "max_speed": 15,                                                                    
+      "time_to_max": 40                                                                    
   },                                                                                      
   "processor": "RP2040",                                                                  
   "split": {                                                                              

--- a/keyboards/svalboard/mouse/info.json
+++ b/keyboards/svalboard/mouse/info.json
@@ -27,10 +27,10 @@
       "rows": ["GP8", "GP7", "GP6", "GP5", "GP4"]                                         
   },                                                                                      
   "mousekey": {                                                                           
-      "delay": 150,                                                                       
-      "interval": 60,                                                                     
-      "max_speed": 5,                                                                     
-      "time_to_max": 7                                                                    
+      "delay": 30,                                                                       
+      "move_delta": 1,
+      "max_speed": 15,                                                                    
+      "time_to_max": 40                                                                    
   },                                                                                      
   "processor": "RP2040",                                                                  
   "split": {                                                                              

--- a/keyboards/svalboard/pointball/left/info.json
+++ b/keyboards/svalboard/pointball/left/info.json
@@ -27,10 +27,10 @@
       "rows": ["GP8", "GP7", "GP6", "GP5", "GP4"]                                         
   },                                                                                      
   "mousekey": {                                                                           
-      "delay": 150,                                                                       
-      "interval": 60,                                                                     
-      "max_speed": 5,                                                                     
-      "time_to_max": 7                                                                    
+      "delay": 30,                                                                       
+      "move_delta": 1,
+      "max_speed": 15,                                                                    
+      "time_to_max": 40                                                                    
   },                                                                                      
   "processor": "RP2040",                                                                  
   "split": {                                                                              

--- a/keyboards/svalboard/pointball/right/info.json
+++ b/keyboards/svalboard/pointball/right/info.json
@@ -27,10 +27,10 @@
       "rows": ["GP8", "GP7", "GP6", "GP5", "GP4"]                                         
   },                                                                                      
   "mousekey": {                                                                           
-      "delay": 150,                                                                       
-      "interval": 60,                                                                     
-      "max_speed": 5,                                                                     
-      "time_to_max": 7                                                                    
+      "delay": 30,                                                                       
+      "move_delta": 1,
+      "max_speed": 15,                                                                    
+      "time_to_max": 40                                                                    
   },                                                                                      
   "processor": "RP2040",                                                                  
   "split": {                                                                              

--- a/keyboards/svalboard/trackball/info.json
+++ b/keyboards/svalboard/trackball/info.json
@@ -27,10 +27,10 @@
       "rows": ["GP8", "GP7", "GP6", "GP5", "GP4"]                                         
   },                                                                                      
   "mousekey": {                                                                           
-      "delay": 150,                                                                       
-      "interval": 60,                                                                     
-      "max_speed": 5,                                                                     
-      "time_to_max": 7                                                                    
+      "delay": 30,                                                                       
+      "move_delta": 1,
+      "max_speed": 15,                                                                    
+      "time_to_max": 40                                                                    
   },                                                                                      
   "processor": "RP2040",                                                                  
   "split": {                                                                              

--- a/keyboards/svalboard/trackpoint/info.json
+++ b/keyboards/svalboard/trackpoint/info.json
@@ -27,10 +27,10 @@
       "rows": ["GP8", "GP7", "GP6", "GP5", "GP4"]                                         
   },                                                                                      
   "mousekey": {                                                                           
-      "delay": 150,                                                                       
-      "interval": 60,                                                                     
-      "max_speed": 5,                                                                     
-      "time_to_max": 7                                                                    
+      "delay": 30,                                                                       
+      "move_delta": 1,
+      "max_speed": 15,                                                                    
+      "time_to_max": 40                                                                    
   },                                                                                      
   "processor": "RP2040",                                                                  
   "split": {                                                                              


### PR DESCRIPTION
Mousekey settings had large `delay` and `interval` set, which made them feel jerky/laggy.

These are more sane defaults, by my (admittedly brief) testing, that still allow decent fine control while being able to get around at a reasonable speed without visible lag.

Other option would be to wipe these entirely in favor of the [default QMK ones](https://github.com/qmk/qmk_firmware/blob/master/docs/feature_mouse_keys.md#accelerated-mode), but those are very fast and hard to control, in my experience.