### PR TITLE
svalboard/keymap: Add changable mouse_keys timers.

### DIFF
--- a/keyboards/svalboard/config.h
+++ b/keyboards/svalboard/config.h
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define FORCE_NKRO
 #define EE_HANDS
 //#define DEBUG_MATRIX_SCAN_RATE
-#define EECONFIG_KB_DATA_SIZE 4
+#define EECONFIG_KB_DATA_SIZE 5
 
 // wiring of each half
 //Layout for svalboard v0 (different from lalboard_v2)

--- a/keyboards/svalboard/keymaps/vial/vial.json
+++ b/keyboards/svalboard/keymaps/vial/vial.json
@@ -40,6 +40,11 @@
         "shortName": "Fix\nDrift",
         "title": "Reset the calibration of the pointing device",
         "name": "SV_RECALIBRATE_POINTER"
+      },
+      {
+        "shortName": "Mouse\nKey\nTimer",
+        "title": "Toggle between various settings of the mouse keys timer.",
+        "name": "SV_MH_CHANGE_TIMEOUTS"
       }
     ],
     "layouts": {

--- a/keyboards/svalboard/svalboard.c
+++ b/keyboards/svalboard/svalboard.c
@@ -16,6 +16,11 @@ void read_eeprom_kb(void) {
         global_saved_values.left_dpi_index=2;
         modified = true;
     }
+    if (global_saved_values.version < 2) {
+        global_saved_values.version = 2;
+        global_saved_values.mh_timer_index = 2;
+        modified = true;
+    }
     // As we add versions, just append here.
     if (modified) {
         write_eeprom_kb();

--- a/keyboards/svalboard/svalboard.h
+++ b/keyboards/svalboard/svalboard.h
@@ -25,6 +25,7 @@ struct saved_values {
     unsigned int unused0 :6;
     uint8_t left_dpi_index;
     uint8_t right_dpi_index;
+    uint8_t mh_timer_index;
 };
 
 typedef struct saved_values saved_values_t;


### PR DESCRIPTION
This adds the mouse key timer toggle to switch through different time amounts for the mouse key layer timer.