### PR TITLE
achordion + keymap: Support for achordion

### DIFF
--- a/keyboards/svalboard/config.h
+++ b/keyboards/svalboard/config.h
@@ -86,3 +86,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_MAX_LAYERS 16 //DYNAMIC_KEYMAP_LAYER_COUNT
 #define RGBLIGHT_VAL_STEP 10
 #define RGBLIGHT_LED_COUNT 2
+
+
+#define PERMISSIVE_HOLD
+#define ACHORDION_STREAK

--- a/keyboards/svalboard/keymaps/features/achordion.c
+++ b/keyboards/svalboard/keymaps/features/achordion.c
@@ -22,6 +22,12 @@
 
 #include "achordion.h"
 
+#if !defined(IS_QK_MOD_TAP)
+// Attempt to detect out-of-date QMK installation, which would fail with
+// implicit-function-declaration errors in the code below.
+#error "achordion: QMK version is too old to build. Please update QMK."
+#else
+
 // Copy of the `record` and `keycode` args for the current active tap-hold key.
 static keyrecord_t tap_hold_record;
 static uint16_t tap_hold_keycode = KC_NO;
@@ -29,6 +35,16 @@ static uint16_t tap_hold_keycode = KC_NO;
 static uint16_t hold_timer = 0;
 // Eagerly applied mods, if any.
 static uint8_t eager_mods = 0;
+// Flag to determine whether another key is pressed within the timeout.
+static bool pressed_another_key_before_release = false;
+
+#ifdef ACHORDION_STREAK
+// Timer for typing streak
+static uint16_t streak_timer = 0;
+#else
+// When disabled, is_streak is never true
+#define is_streak false
+#endif
 
 // Achordion's current state.
 enum {
@@ -73,6 +89,14 @@ bool process_achordion(uint16_t keycode, keyrecord_t* record) {
     return true;
   }
 
+  // If this is a keypress and if the key is different than the tap-hold key,
+  // this information is saved to a flag to be processed later when the tap-hold
+  // key is released.
+  if (!pressed_another_key_before_release && record->event.pressed &&
+      tap_hold_keycode != KC_NO && tap_hold_keycode != keycode) {
+    pressed_another_key_before_release = true;
+  }
+
   // Determine whether the current event is for a mod-tap or layer-tap key.
   const bool is_mt = IS_QK_MOD_TAP(keycode);
   const bool is_tap_hold = is_mt || IS_QK_LAYER_TAP(keycode);
@@ -80,8 +104,8 @@ bool process_achordion(uint16_t keycode, keyrecord_t* record) {
 #ifdef IS_KEYEVENT
   const bool is_key_event = IS_KEYEVENT(record->event);
 #else
-  const bool is_key_event = (record->event.key.row < 254 &&
-                             record->event.key.col < 254);
+  const bool is_key_event =
+      (record->event.key.row < 254 && record->event.key.col < 254);
 #endif
 
   if (achordion_state == STATE_RELEASED) {
@@ -110,6 +134,9 @@ bool process_achordion(uint16_t keycode, keyrecord_t* record) {
       }
     }
 
+#ifdef ACHORDION_STREAK
+    streak_timer = (timer_read() + achordion_streak_timeout(keycode)) | 1;
+#endif
     return true;  // Otherwise, continue with default handling.
   }
 
@@ -117,6 +144,15 @@ bool process_achordion(uint16_t keycode, keyrecord_t* record) {
     // The active tap-hold key is being released.
     if (achordion_state == STATE_HOLDING) {
       dprintln("Achordion: Key released. Plumbing hold release.");
+      tap_hold_record.event.pressed = false;
+      // Plumb hold release event.
+      recursively_process_record(&tap_hold_record, STATE_RELEASED);
+    } else if (!pressed_another_key_before_release) {
+      // No other key was pressed between the press and release of the tap-hold
+      // key, simulate a hold and then a release without waiting for Achordion
+      // timeout to end.
+      dprintln("Achordion: Key released. Simulating hold and release.");
+      settle_as_hold();
       tap_hold_record.event.pressed = false;
       // Plumb hold release event.
       recursively_process_record(&tap_hold_record, STATE_RELEASED);
@@ -129,10 +165,18 @@ bool process_achordion(uint16_t keycode, keyrecord_t* record) {
     }
 
     achordion_state = STATE_RELEASED;
+    // The tap-hold key is released, clear the related keycode and the flag.
+    tap_hold_keycode = KC_NO;
+    pressed_another_key_before_release = false;
     return false;
   }
 
   if (achordion_state == STATE_UNSETTLED && record->event.pressed) {
+#ifdef ACHORDION_STREAK
+    const bool is_streak = (streak_timer != 0);
+    streak_timer = (timer_read() + achordion_streak_timeout(keycode)) | 1;
+#endif
+
     // Press event occurred on a key other than the active tap-hold key.
 
     // If the other key is *also* a tap-hold key and considered by QMK to be
@@ -145,10 +189,21 @@ bool process_achordion(uint16_t keycode, keyrecord_t* record) {
     // events back into the handling pipeline so that QMK features and other
     // user code can see them. This is done by calling `process_record()`, which
     // in turn calls most handlers including `process_record_user()`.
-    if (!is_key_event || (is_tap_hold && record->tap.count == 0) ||
-        achordion_chord(tap_hold_keycode, &tap_hold_record, keycode, record)) {
+    if (!is_streak && (!is_key_event || (is_tap_hold && record->tap.count == 0) ||
+        achordion_chord(tap_hold_keycode, &tap_hold_record, keycode, record))) {
       dprintln("Achordion: Plumbing hold press.");
       settle_as_hold();
+
+#ifdef REPEAT_KEY_ENABLE
+      // Edge case involving LT + Repeat Key: in a sequence of "LT down, other
+      // down" where "other" is on the other layer in the same position as
+      // Repeat or Alternate Repeat, the repeated keycode is set instead of the
+      // the one on the switched-to layer. Here we correct that.
+      if (get_repeat_key_count() != 0 && IS_QK_LAYER_TAP(tap_hold_keycode)) {
+        record->keycode = KC_NO;  // Forget the repeated keycode.
+        clear_weak_mods();
+      }
+#endif  // REPEAT_KEY_ENABLE
     } else {
       clear_eager_mods();  // Clear in case eager mods were set.
 
@@ -173,6 +228,10 @@ bool process_achordion(uint16_t keycode, keyrecord_t* record) {
     return false;  // Block the original event.
   }
 
+#ifdef ACHORDION_STREAK
+  // update idle timer on regular keys event
+  streak_timer = (timer_read() + achordion_streak_timeout(keycode)) | 1;
+#endif
   return true;
 }
 
@@ -182,6 +241,12 @@ void achordion_task(void) {
     dprintln("Achordion: Timeout. Plumbing hold press.");
     settle_as_hold();  // Timeout expired, settle the key as held.
   }
+
+#ifdef ACHORDION_STREAK
+  if (streak_timer && timer_expired(timer_read(), streak_timer)) {
+    streak_timer = 0;  // Expired.
+  }
+#endif
 }
 
 // Returns true if `pos` on the left hand of the keyboard, false if right.
@@ -218,3 +283,11 @@ __attribute__((weak)) uint16_t achordion_timeout(uint16_t tap_hold_keycode) {
 __attribute__((weak)) bool achordion_eager_mod(uint8_t mod) {
   return (mod & (MOD_LALT | MOD_LGUI)) == 0;
 }
+
+#ifdef ACHORDION_STREAK
+__attribute__((weak)) uint16_t achordion_streak_timeout(uint16_t tap_hold_keycode) {
+  return 100;  // Default of 100 ms.
+}
+#endif
+
+#endif  // version check

--- a/keyboards/svalboard/keymaps/features/achordion.h
+++ b/keyboards/svalboard/keymaps/features/achordion.h
@@ -53,6 +53,27 @@
 
 #include "quantum.h"
 
+/**
+ * Suppress tap-hold mods within a *typing streak* by defining
+ * ACHORDION_STREAK. This can help preventing accidental mod
+ * activation when performing a fast tapping sequence.
+ * This is inspired by https://sunaku.github.io/home-row-mods.html#typing-streaks
+ *
+ * Enable with:
+ *
+ *    #define ACHORDION_STREAK
+ *
+ * Adjust the maximum time between key events before modifiers can be enabled
+ * by defining the following callback in your keymap.c:
+ *
+ *    uint16_t achordion_streak_timeout(uint16_t tap_hold_keycode) {
+ *      return 100;  // Default of 100 ms.
+ *    }
+ */
+#ifdef ACHORDION_STREAK
+uint16_t achordion_streak_timeout(uint16_t tap_hold_keycode);
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/keyboards/svalboard/keymaps/vial/keymap.c
+++ b/keyboards/svalboard/keymaps/vial/keymap.c
@@ -32,7 +32,7 @@ LAYER_COLOR(layer3_colors, HSV_ORANGE); // FUNC_HOLD
 LAYER_COLOR(layer4_colors, HSV_AZURE); // NAS
 LAYER_COLOR(layer5_colors, HSV_AZURE); // would be NAS hold
 LAYER_COLOR(layer6_colors, HSV_RED); // maybe 10kp
-LAYER_COLOR(layer7_colors, HSV_GOLDENROD);
+LAYER_COLOR(layer7_colors, HSV_RED);
 LAYER_COLOR(layer8_colors, HSV_PINK);
 LAYER_COLOR(layer9_colors, HSV_PURPLE);
 LAYER_COLOR(layer10_colors, HSV_CORAL);
@@ -67,7 +67,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 void keyboard_post_init_user(void) {
   // Customise these values if you need to debug the matrix
   //debug_enable=true;
-  debug_matrix=true;
+  //debug_matrix=true;
   //debug_keyboard=true;
   //debug_mouse=true;
   rgblight_layers = sval_rgb_layers;
@@ -184,3 +184,14 @@ const uint16_t PROGMEM keymaps[DYNAMIC_KEYMAP_LAYER_COUNT][MATRIX_ROWS][MATRIX_C
         )
 
 };
+
+bool achordion_chord(uint16_t tap_hold_keycode, keyrecord_t* tap_hold_record,
+                     uint16_t other_keycode, keyrecord_t* other_record) {
+    if (tap_hold_record->event.key.row == 0 || tap_hold_record->event.key.row == 5 ||
+        other_record->event.key.row    == 0 || other_record->event.key.row    == 5) {
+        return true;
+    }
+
+    return achordion_opposite_hands(tap_hold_record, other_record);
+}
+

--- a/keyboards/svalboard/keymaps/vial/rules.mk
+++ b/keyboards/svalboard/keymaps/vial/rules.mk
@@ -1,3 +1,6 @@
 VIA_ENABLE = yes
 VIAL_ENABLE = yes
-VIAL_INSECURE = yes
+VIAL_INSECURE ?= yes
+CAPS_WORD_ENABLE = yes
+
+SRC += ../features/achordion.c

--- a/keyboards/svalboard/keymaps/vial/vial.json
+++ b/keyboards/svalboard/keymaps/vial/vial.json
@@ -45,6 +45,26 @@
         "shortName": "Mouse\nKey\nTimer",
         "title": "Toggle between various settings of the mouse keys timer.",
         "name": "SV_MH_CHANGE_TIMEOUTS"
+      },
+      {
+        "shortName": "Caps\nWord\nToggle",
+        "title": "Toggle Caps Word.",
+        "name": "SV_CAPS_WORD"
+      },
+      {
+        "shortName": "Toggle\nACH",
+        "title": "Toggle Achordion",
+        "name": "SV_TOGGLE_ACHORDION"
+      },
+      {
+        "shortName": "MO 23\n(45=67)",
+        "title": "Toggle layer 2 and 3, if 4 and 5 also active toggle 6 and 7",
+        "name": "SV_TOGGLE_23_67"
+      },
+      {
+        "shortName": "MO 45\n(23=67)",
+        "title": "Toggle layer 4 and 5, if 2 and 3 also active toggle 6 and 7",
+        "name": "SV_TOGGLE_45_67"
       }
     ],
     "layouts": {

--- a/keyboards/svalboard/keymaps/vial/vial.json
+++ b/keyboards/svalboard/keymaps/vial/vial.json
@@ -43,7 +43,7 @@
       },
       {
         "shortName": "Mouse\nKey\nTimer",
-        "title": "Toggle between various settings of the mouse keys timer.",
+        "title": "Cycle between various settings of the mouse keys timer.",
         "name": "SV_MH_CHANGE_TIMEOUTS"
       },
       {

--- a/keyboards/svalboard/svalboard.h
+++ b/keyboards/svalboard/svalboard.h
@@ -22,7 +22,8 @@ struct saved_values {
     uint8_t version;  // Currently at 1,  We assume all new data will be zeroed.
     bool left_scroll :1;
     bool right_scroll :1;
-    unsigned int unused0 :6;
+    bool disable_achordion: 1;
+    unsigned int unused0 :5;
     uint8_t left_dpi_index;
     uint8_t right_dpi_index;
     uint8_t mh_timer_index;


### PR DESCRIPTION
Support achordion, a library to help with home row modifier usage, and bottom row modifier usage.

This also adds the ability to hold down two layers at once, in 3 pairs, 23, 45 and if both are held 67.

Along with this, there is a change to allow KC_TRANSPARENT to be used along with mod tap, as long as the mod_tap is on the top active layer.  This is needed for bottom row modifier support on Dvorak to have a sane NAS layer.