### PR TITLE
svalboard: Make it so the keyboard can print out internal state.

### DIFF
--- a/keyboards/svalboard/keymaps/6key/vial.json
+++ b/keyboards/svalboard/keymaps/6key/vial.json
@@ -90,7 +90,12 @@
         "shortName": "Scroll\nRight\nHold",
         "title": "Hold to make the right pointing device scroll",
         "name": "SV_RIGHT_SCROLL_HOLD"
-      }
+      },
+      {
+	"shortName": "Output\nStatus",
+	"title": "Output the current internal state of the keyboard.",
+	"name": "SV_OUTPUT_STATUS"
+      }    
     ],
     "layouts": {
     "labels": [

--- a/keyboards/svalboard/keymaps/keymap_support.c
+++ b/keyboards/svalboard/keymaps/keymap_support.c
@@ -22,8 +22,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "features/achordion.h"
 #include "keymap_support.h"
 
-const uint16_t mh_timer_choices[] = { 300, 500, -1}; // -1 is infinite.
-
 #define PS2_MOUSE_SCROLL_BTN_MASK (1<<PS2_MOUSE_BTN_MIDDLE) // this mask disables the key for non-PS2 purposes
 
 // in keymap.c:
@@ -355,7 +353,9 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                 snipe_x /= 5;
                 snipe_y /= 5;
                 break;
-            default:
+	    case SV_OUTPUT_STATUS:
+	        output_keyboard_info();
+	    default:
                 break;
         }
     }

--- a/keyboards/svalboard/keymaps/keymap_support.h
+++ b/keyboards/svalboard/keymaps/keymap_support.h
@@ -39,6 +39,7 @@ enum my_keycodes {
     SV_SNIPER_5,
     SV_LEFT_SCROLL_HOLD,
     SV_RIGHT_SCROLL_HOLD,
+    SV_OUTPUT_STATUS,
     // New keycodes should go here, to avoid breaking existing keymaps - order must match vial.json
     KC_NORMAL_HOLD = SAFE_RANGE,
     KC_FUNC_HOLD,

--- a/keyboards/svalboard/keymaps/vial/vial.json
+++ b/keyboards/svalboard/keymaps/vial/vial.json
@@ -90,7 +90,12 @@
         "shortName": "Scroll\nRight\nHold",
         "title": "Hold to make the right pointing device scroll",
         "name": "SV_RIGHT_SCROLL_HOLD"
-      }
+      },
+      {
+	"shortName": "Output\nStatus",
+	"title": "Output the current internal state of the keyboard.",
+	"name": "SV_OUTPUT_STATUS"
+      }    
     ],
     "layouts": {
       "keymap": [

--- a/keyboards/svalboard/svalboard.c
+++ b/keyboards/svalboard/svalboard.c
@@ -1,7 +1,9 @@
 #include "svalboard.h"
 #include "eeconfig.h"
+#include "version.h"
 
 saved_values_t global_saved_values;
+const int16_t mh_timer_choices[3] = { 300, 500, -1 }; // -1 is infinite.
 
 void write_eeprom_kb(void) {
     eeconfig_update_kb_datablock(&global_saved_values);
@@ -27,8 +29,34 @@ void read_eeprom_kb(void) {
     }
 }
 
+static const char YES[] = "yes";
+static const char NO[] = "no";
+
+const char *yes_or_no(int flag) {
+    if (flag) {
+	return YES;
+    } else {
+	return NO;
+    }
+}
+
 const uint16_t dpi_choices[] = { 200, 400, 800, 1200, 1600, 2400 }; // If we need more, add them.
 #define DPI_CHOICES_LENGTH (sizeof(dpi_choices)/sizeof(dpi_choices[0]))
+
+void output_keyboard_info(void) {
+    char output_buffer[256];
+
+    sprintf(output_buffer, "%s:%s @ %s\n", QMK_KEYBOARD, QMK_KEYMAP, QMK_VERSION);
+    send_string(output_buffer);
+    sprintf(output_buffer, "Left Ptr: Scroll %s, cpi: %d, Right Ptr: Scroll %s, cpi: %d\n",
+	    yes_or_no(global_saved_values.left_scroll), dpi_choices[global_saved_values.left_dpi_index],
+	    yes_or_no(global_saved_values.right_scroll), dpi_choices[global_saved_values.right_dpi_index]);
+    send_string(output_buffer);
+    sprintf(output_buffer, "Achordion: %s, MH Keys Timer: %d\n",
+	    yes_or_no(!global_saved_values.disable_achordion),
+	    mh_timer_choices[global_saved_values.mh_timer_index]);
+    send_string(output_buffer);
+}
 
 void increase_left_dpi(void) {
     if (global_saved_values.left_dpi_index + 1 < DPI_CHOICES_LENGTH) {

--- a/keyboards/svalboard/svalboard.h
+++ b/keyboards/svalboard/svalboard.h
@@ -18,6 +18,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "quantum.h"
 
+extern const int16_t mh_timer_choices[3];
+
 struct saved_values {
     uint8_t version;  // Currently at 1,  We assume all new data will be zeroed.
     bool left_scroll :1;
@@ -32,7 +34,7 @@ struct saved_values {
 typedef struct saved_values saved_values_t;
 
 extern saved_values_t global_saved_values;
-
+void output_keyboard_info(void);
 void increase_left_dpi(void);
 void increase_right_dpi(void);
 void decrease_left_dpi(void);


### PR DESCRIPTION
This adds the basic ability for the keyboard to output internal state as if the user were typing.

We hope to replace this with better functionality long term but for now it is needed.