### PR TITLE
Move capsword to info.json and enable shift invert

### DIFF
--- a/keyboards/svalboard/info.json
+++ b/keyboards/svalboard/info.json
@@ -44,6 +44,10 @@
   "tapping": {
       "term": 200
   },
+  "caps_word": {
+    "enabled": true,
+    "invert_on_shift": true
+  },
   "usb": {
       "device_version": "0.0.2",
       "pid": "0x4044",

--- a/keyboards/svalboard/keymaps/6key/rules.mk
+++ b/keyboards/svalboard/keymaps/6key/rules.mk
@@ -1,6 +1,5 @@
 VIA_ENABLE = yes
 VIAL_ENABLE = yes
 VIAL_INSECURE ?= yes
-CAPS_WORD_ENABLE = yes
 
 SRC += ../features/achordion.c

--- a/keyboards/svalboard/keymaps/vial/rules.mk
+++ b/keyboards/svalboard/keymaps/vial/rules.mk
@@ -1,6 +1,5 @@
 VIA_ENABLE = yes
 VIAL_ENABLE = yes
 VIAL_INSECURE ?= yes
-CAPS_WORD_ENABLE = yes
 
 SRC += ../features/achordion.c


### PR DESCRIPTION
Defining it in info.json in more "modern" and reduces duplication. We should be using rules.mk for specific hardware overrides only, probably.

This also enables CAPS_WORD_INVERT_ON_SHIFT since it has few real downsides and is useful.  Also perhaps follows the principle of least surprise, since it makes caps word's behavior match caps lock, which people are more likely familiar with.