### PR TITLE
Blank and thumb fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,6 @@ jobs:
     strategy:
       matrix:
         keyboard: [ svalboard ]
-        keymap: [ vial ]
+        keymap: [ blank ]
         side: [ left, right ]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 permissions: write-all
 
 jobs:
-  build:
+  build_vial:
     uses: ./.github/workflows/build-firmware.yml
     with:
       keyboard: ${{ matrix.keyboard }}
@@ -23,4 +23,17 @@ jobs:
         keyboard: [ svalboard/trackpoint, svalboard, svalboard/trackball/pmw3360, svalboard/trackball/pmw3389 ]
         keymap: [ vial ]
         side: [ left, right ]
-        
+
+  build_blank:
+    uses: ./.github/workflows/build-firmware.yml
+    with:
+      keyboard: ${{ matrix.keyboard }}
+      keymap: ${{ matrix.keymap }}
+      side: ${{ matrix.side }}
+
+    strategy:
+      matrix:
+        keyboard: [ svalboard ]
+        keymap: [ vial ]
+        side: [ left, right ]
+

--- a/keyboards/svalboard/config.h
+++ b/keyboards/svalboard/config.h
@@ -41,6 +41,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define THUMB_DOWN_ACTIVE_DARK
 
 #define MATRIX_COL_PUSHED_STATES { 0, 0, 1, 0, 0, 0 }
+#ifdef THUMB_DOWN_ACTIVE_DARK
+    #define MATRIX_COL_PUSHED_STATES_THUMBS { 0, 0, 1, 0, 0, 0 }
+#else
+    #define MATRIX_COL_PUSHED_STATES_THUMBS { 0, 0, 0, 0, 0, 0 }
+#endif
 #define DOUBLEDOWN_COL 5 // need a pullup on COL6
 #define PREWAIT_US 90
 #define POSTWAIT_US 90

--- a/keyboards/svalboard/keymaps/blank/config.h
+++ b/keyboards/svalboard/keymaps/blank/config.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#pragma once
+
+#define VIAL_KEYBOARD_UID {0x1B, 0x18, 0x7D, 0xF2, 0x21, 0xF6, 0x29, 0x48}
+
+// Vial security combos, depending on which unit this is...
+#ifdef INIT_EE_HANDS_RIGHT
+// right thumb lock
+#define VIAL_UNLOCK_COMBO_ROWS { 5, 5 }
+#define VIAL_UNLOCK_COMBO_COLS { 0, 1 }
+#elif INIT_EE_HANDS_LEFT
+// left thumb lock
+#define VIAL_UNLOCK_COMBO_ROWS { 0, 0 }
+#define VIAL_UNLOCK_COMBO_COLS { 0, 1 }
+#else
+// both thumb locks
+#define VIAL_UNLOCK_COMBO_ROWS { 0, 0, 5, 5 }
+#define VIAL_UNLOCK_COMBO_COLS { 2, 5, 2, 5 }
+#endif
+
+// Shorten the unlock timeout (needs mod in `quantum/vial.c`; without
+// it the override doesn't work)
+#define VIAL_UNLOCK_COUNTER_MAX 12

--- a/keyboards/svalboard/keymaps/blank/keymap.c
+++ b/keyboards/svalboard/keymaps/blank/keymap.c
@@ -1,0 +1,97 @@
+/*
+Copyright 2023 Morgan Venable @_claussen
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "../keymap_support.c"
+#include "keycodes.h"
+#include "quantum_keycodes.h"
+#include QMK_KEYBOARD_H
+#include <stdbool.h>
+#include <stdint.h>
+#include "svalboard.h"
+
+#define LAYER_COLOR(name, color) rgblight_segment_t const (name)[] = RGBLIGHT_LAYER_SEGMENTS({0, 2, color})
+
+LAYER_COLOR(layer0_colors, HSV_GREEN); // NORMAL
+LAYER_COLOR(layer1_colors, HSV_GREEN); // NORMAL_HOLD
+LAYER_COLOR(layer2_colors, HSV_ORANGE); // FUNC
+LAYER_COLOR(layer3_colors, HSV_ORANGE); // FUNC_HOLD
+LAYER_COLOR(layer4_colors, HSV_AZURE); // NAS
+LAYER_COLOR(layer5_colors, HSV_AZURE); // would be NAS hold
+LAYER_COLOR(layer6_colors, HSV_RED); // maybe 10kp
+LAYER_COLOR(layer7_colors, HSV_RED);
+LAYER_COLOR(layer8_colors, HSV_PINK);
+LAYER_COLOR(layer9_colors, HSV_PURPLE);
+LAYER_COLOR(layer10_colors, HSV_CORAL);
+LAYER_COLOR(layer11_colors, HSV_SPRINGGREEN);
+LAYER_COLOR(layer12_colors, HSV_TEAL);
+LAYER_COLOR(layer13_colors, HSV_TURQUOISE);
+LAYER_COLOR(layer14_colors, HSV_YELLOW);
+LAYER_COLOR(layer15_colors, HSV_MAGENTA); // MBO
+#undef LAYER_COLOR
+
+const rgblight_segment_t*  const __attribute((weak))sval_rgb_layers[] = RGBLIGHT_LAYERS_LIST(
+    layer0_colors, layer1_colors, layer2_colors, layer3_colors,
+    layer4_colors, layer5_colors, layer6_colors, layer7_colors,
+    layer8_colors, layer9_colors, layer10_colors, layer11_colors,
+    layer12_colors, layer13_colors, layer14_colors, layer15_colors
+);
+
+layer_state_t default_layer_state_set_user(layer_state_t state) {
+  rgblight_set_layer_state(0, layer_state_cmp(state, 0));
+  return state;
+}
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+  for (int i = 0; i < RGBLIGHT_LAYERS; ++i) {
+      rgblight_set_layer_state(i, layer_state_cmp(state, i));
+  }
+  return state;
+}
+
+
+
+void keyboard_post_init_user(void) {
+  // Customise these values if you need to debug the matrix
+  //debug_enable=true;
+  //debug_matrix=true;
+  //debug_keyboard=true;
+  //debug_mouse=true;
+  rgblight_layers = sval_rgb_layers;
+}
+
+enum layer {
+    NORMAL,
+    NORMAL_HOLD,
+    FUNC,
+    FUNC_HOLD,
+    NAS,
+    MBO = MH_AUTO_BUTTONS_LAYER,
+};
+
+const uint16_t PROGMEM keymaps[DYNAMIC_KEYMAP_LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS] = {
+};
+
+bool achordion_chord(uint16_t tap_hold_keycode, keyrecord_t* tap_hold_record,
+                     uint16_t other_keycode, keyrecord_t* other_record) {
+    if (tap_hold_record->event.key.row == 0 || tap_hold_record->event.key.row == 5 ||
+        other_record->event.key.row    == 0 || other_record->event.key.row    == 5) {
+        return true;
+    }
+
+    return achordion_opposite_hands(tap_hold_record, other_record);
+}
+

--- a/keyboards/svalboard/keymaps/blank/rules.mk
+++ b/keyboards/svalboard/keymaps/blank/rules.mk
@@ -1,0 +1,5 @@
+VIA_ENABLE = yes
+VIAL_ENABLE = yes
+VIAL_INSECURE ?= yes
+
+SRC += ../features/achordion.c

--- a/keyboards/svalboard/keymaps/blank/vial.json
+++ b/keyboards/svalboard/keymaps/blank/vial.json
@@ -1,0 +1,377 @@
+{
+    "name": "Svalboard Vial Definition",
+    "author": "Morgan Venable",
+    "notes": "This is a Vial Keymap template for Svalboard",
+    "vendorId":"0x303A",
+    "productId":"0x4044",
+    "lighting": "none",
+    "matrix": {
+        "rows": 10,
+        "cols": 6
+    },
+    "customKeycodes": [
+      {"shortName": "Left\nDPI +",
+       "title": "Increase the DPI of the left pointing device.",
+       "name": "SV_LEFT_DPI_INC"
+      },
+      {"shortName": "Left\nDPI -",
+       "title": "Decrease the DPI of the left pointing device.",
+       "name": "SV_LEFT_DPI_DEC"
+      },
+      {"shortName": "Right\nDPI +",
+       "title": "Increase the DPI of the right pointing device.",
+       "name": "SV_RIGHT_DPI_INC"
+      },
+      {"shortName": "Right\nDPI -",
+       "title": "Decrease the DPI of the right pointing device.",
+       "name": "SV_RIGHT_DPI_DEC"
+      },
+      {
+        "shortName": "Scroll\nLeft\nToggle",
+        "title": "Toggle if the left pointer is scroll or pointer.",
+        "name": "SV_LEFT_SCROLL_TOGGLE"
+      },
+      {
+        "shortName": "Scroll\nRight\nToggle",
+        "title": "Toggle if the right pointer is scroll or pointer.",
+        "name": "SV_RIGHT_SCROLL_TOGGLE"
+      },
+      {
+        "shortName": "Fix\nDrift",
+        "title": "Reset the calibration of the pointing device",
+        "name": "SV_RECALIBRATE_POINTER"
+      },
+      {
+        "shortName": "Mouse\nKey\nTimer",
+        "title": "Cycle between various settings of the mouse keys timer.",
+        "name": "SV_MH_CHANGE_TIMEOUTS"
+      },
+      {
+        "shortName": "Caps\nWord\nToggle",
+        "title": "Toggle Caps Word.",
+        "name": "SV_CAPS_WORD"
+      },
+      {
+        "shortName": "Toggle\nACH",
+        "title": "Toggle Achordion",
+        "name": "SV_TOGGLE_ACHORDION"
+      },
+      {
+        "shortName": "MO 23\n(45=67)",
+        "title": "Toggle layer 2 and 3, if 4 and 5 also active toggle 6 and 7",
+        "name": "SV_TOGGLE_23_67"
+      },
+      {
+        "shortName": "MO 45\n(23=67)",
+        "title": "Toggle layer 4 and 5, if 2 and 3 also active toggle 6 and 7",
+        "name": "SV_TOGGLE_45_67"
+      },
+      {
+        "shortName": "Sniper\n2x",
+        "title": "Slow the cursor 2x more.",
+        "name": "SV_SNIPER_2"
+      },
+      {
+        "shortName": "Sniper\n3x",
+        "title": "Slow the cursor 3x more.",
+        "name": "SV_SNIPER_3"
+      },
+      {
+        "shortName": "Sniper\n5x",
+        "title": "Slow the cursor 5x more.",
+        "name": "SV_SNIPER_5"
+      },
+      {
+        "shortName": "Scroll\nLeft\nHold",
+        "title": "Hold to make the left pointing device scroll",
+        "name": "SV_LEFT_SCROLL_HOLD"
+      },
+      {
+        "shortName": "Scroll\nRight\nHold",
+        "title": "Hold to make the right pointing device scroll",
+        "name": "SV_RIGHT_SCROLL_HOLD"
+      },
+      {
+	"shortName": "Output\nStatus",
+	"title": "Output the current internal state of the keyboard.",
+	"name": "SV_OUTPUT_STATUS"
+      }    
+    ],
+    "layouts": {
+    "labels": [
+      "Normal",
+      [
+        "SS",
+        "No SS",
+        "SS"
+      ]
+    ],
+      "keymap": [
+  [
+    {
+      "x": 3.5
+    },
+    "3,3",
+    {
+      "x": 2.5
+    },
+    "2,3",
+    {
+      "x": 9
+    },
+    "7,3",
+    {
+      "x": 2.5
+    },
+    "8,3"
+  ],
+  [
+    {
+      "x": 2.5
+    },
+    "3,4",
+    "3,2",
+    "3,1",
+    {
+      "x": 0.5
+    },
+    "2,4",
+    "2,2",
+    "2,1",
+    {
+      "x": 7
+    },
+    "7,4",
+    "7,2",
+    "7,1",
+    {
+      "x": 0.5
+    },
+    "8,4",
+    "8,2",
+    "8,1"
+  ],
+  [
+    {
+      "y": -0.5,
+      "x": 1
+    },
+    "4,3",
+    {
+      "x": 7.5
+    },
+    "1,3",
+    {
+      "x": 4
+    },
+    "6,3",
+    {
+      "x": 7.5
+    },
+    "9,3"
+  ],
+  [
+    {
+      "y": -0.5,
+      "x": 3.5
+    },
+    "3,0",
+    {
+      "x": 2.5
+    },
+    "2,0",
+    {
+      "x": 9
+    },
+    "7,0",
+    {
+      "x": 2.5
+    },
+    "8,0"
+  ],
+  [
+    {
+      "y": -0.5
+    },
+    "4,4",
+    "4,2",
+    "4,1",
+    {
+      "x": 5.5
+    },
+    "1,4",
+    "1,2",
+    "1,1",
+    {
+      "x": 2
+    },
+    "6,4",
+    "6,2",
+    "6,1",
+    {
+      "x": 5.5
+    },
+    "9,4",
+    "9,2",
+    "9,1"
+  ],
+  [
+    {
+      "y": -0.5,
+      "x": 3.5
+    },
+    "3,5\n\n\n1,1",
+    {
+      "x": -1,
+      "d": true
+    },
+    "\n\n\n1,0",
+    {
+      "x": 2.5
+    },
+    "2,5\n\n\n1,1",
+    {
+      "x": -1,
+      "d": true
+    },
+    "\n\n\n1,0",
+    {
+      "x": 9
+    },
+    "7,5\n\n\n1,1",
+    {
+      "x": -1,
+      "d": true
+    },
+    "\n\n\n1,0",
+    {
+      "x": 2.5
+    },
+    "8,5\n\n\n1,1",
+    {
+      "x": -1,
+      "d": true
+    },
+    "\n\n\n1,0"
+  ],
+  [
+    {
+      "y": -0.5,
+      "x": 1
+    },
+    "4,0",
+    {
+      "x": 7.5
+    },
+    "1,0",
+    {
+      "x": 4
+    },
+    "6,0",
+    {
+      "x": 7.5
+    },
+    "9,0"
+  ],
+  [
+    {
+      "x": 1
+    },
+    "4,5\n\n\n1,1",
+    {
+      "x": -1,
+      "d": true
+    },
+    "\n\n\n1,0",
+    {
+      "x": 7.5
+    },
+    "1,5\n\n\n1,1",
+    {
+      "x": -1,
+      "d": true
+    },
+    "\n\n\n1,0",
+    {
+      "x": 4
+    },
+    "6,5\n\n\n1,1",
+    {
+      "x": -1,
+      "d": true
+    },
+    "\n\n\n1,0",
+    {
+      "x": 7.5
+    },
+    "9,5\n\n\n1,1",
+    {
+      "x": -1,
+      "d": true
+    },
+    "\n\n\n1,0"
+  ],
+  [
+    {
+      "y": 0.5,
+      "x": 7.9,
+      "w": 1.5
+    },
+    "0,3",
+    {
+      "x": 0.09999999999999964
+    },
+    "0,5",
+    {
+      "x": 0.09999999999999964,
+      "w": 1.5
+    },
+    "0,1",
+    {
+      "x": 0.8000000000000007,
+      "w": 1.5
+    },
+    "5,1",
+    {
+      "x": 0.09999999999999964
+    },
+    "5,5",
+    {
+      "x": 0.09999999999999964,
+      "w": 1.5
+    },
+    "5,3"
+  ],
+  [
+    {
+      "x": 7.4,
+      "w": 2
+    },
+    "0,4",
+    {
+      "x": 0.09999999999999964
+    },
+    "0,2",
+    {
+      "x": 0.09999999999999964,
+      "w": 1.5
+    },
+    "0,0",
+    {
+      "x": 0.8000000000000007,
+      "w": 1.5
+    },
+    "5,0",
+    {
+      "x": 0.09999999999999964
+    },
+    "5,2",
+    {
+      "x": 0.09999999999999964,
+      "w": 2
+    },
+    "5,4"
+  ]
+]
+    }
+}

--- a/keyboards/svalboard/matrix.c
+++ b/keyboards/svalboard/matrix.c
@@ -30,7 +30,7 @@ const pin_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
 const pin_t row_pins[ROWS_PER_HAND] = MATRIX_ROW_PINS;
 //static const uint8_t col_pushed_states[MATRIX_COLS] = MATRIX_COL_PUSHED_STATES;
 static const uint8_t col_pushed_states_fingers[MATRIX_COLS] = MATRIX_COL_PUSHED_STATES;
-static uint8_t col_pushed_states_thumbs[MATRIX_COLS] = { 0 };
+static const uint8_t col_pushed_states_thumbs[MATRIX_COLS] = MATRIX_COL_PUSHED_STATES_THUMBS;
 
 static inline void setPinOutput_writeLow(pin_t pin) {
     ATOMIC_BLOCK_FORCEON {
@@ -96,7 +96,6 @@ static void unselect_rows(void) {
 extern matrix_row_t raw_matrix[ROWS_PER_HAND]; // raw values
 extern matrix_row_t matrix[ROWS_PER_HAND];     // debounced values
 
-static bool first_matrix_scan = true;
 void matrix_read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row) {
     // Start with a clear matrix row
     matrix_row_t current_row_value = 0;
@@ -110,12 +109,7 @@ void matrix_read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     for (uint8_t col_index = 0; col_index < MATRIX_COLS; col_index++) {
         uint8_t pin_state;
         if (current_row == 0) {
-            if (first_matrix_scan) {
-                col_pushed_states_thumbs[col_index] = readPin(col_pins[col_index]) ? 0 : 1; // This is inverted for reasons, not understood.
-                pin_state = 0;
-            } else {
-                pin_state = (readPin(col_pins[col_index]) == col_pushed_states_thumbs[col_index]) ? 1 : 0; // read pin and match pushed_states define
-            }
+            pin_state = (readPin(col_pins[col_index]) == col_pushed_states_thumbs[col_index]) ? 1 : 0;  // read pin and match pushed_states define
         } else {
             pin_state = (readPin(col_pins[col_index]) == col_pushed_states_fingers[col_index]) ? 1 : 0;  // read pin and match pushed_states define
         }
@@ -127,7 +121,6 @@ void matrix_read_cols_on_row(matrix_row_t current_matrix[], uint8_t current_row)
     unselect_row(current_row);
     wait_us(POSTWAIT_US);
 
-    first_matrix_scan = false;
     // Update the matrix
     current_matrix[current_row] = current_row_value;
 }


### PR DESCRIPTION
The blank keymap has many uses, we've discovered, so it
has been added back into svalboard.  It is intended for
troubleshooting only.  Use vial for the main keymap.
    
Autodetecting thumbs have been removed due to them
being counter-intuitive to almost all users.