### PR TITLE
increase default brightness for visibility

### DIFF
--- a/keyboards/svalboard/config.h
+++ b/keyboards/svalboard/config.h
@@ -86,7 +86,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RGBLIGHT_LAYERS DYNAMIC_KEYMAP_LAYER_COUNT
 #define RGBLIGHT_DEFAULT_SAT 0 // white?
 #define RGBLIGHT_LIMIT_VAL 255
-#define RGBLIGHT_DEFAULT_VAL 20
+#define RGBLIGHT_DEFAULT_VAL 128
 #define RGBLIGHT_SLEEP // don't annoy when host asleep
 #define RGBLIGHT_MAX_LAYERS 16 //DYNAMIC_KEYMAP_LAYER_COUNT
 #define RGBLIGHT_VAL_STEP 10


### PR DESCRIPTION
just increases brightness  to 50% by default -- folks with poor contrast vision can't even see the lights at previous ~8% default