### PR TITLE
Use all flash

### DIFF
--- a/keyboards/svalboard/config.h
+++ b/keyboards/svalboard/config.h
@@ -31,6 +31,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define DEBUG_MATRIX_SCAN_RATE
 #define EECONFIG_KB_DATA_SIZE 5
 
+
+#define FLASH_LEN (16 * 1024 * 1024)
+#define WEAR_LEVELING_BACKING_SIZE (128 * 1024)
 // wiring of each half
 //Layout for svalboard v0 (different from lalboard_v2)
 //1 2 3 4 5 6
@@ -54,7 +57,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_TIMEOUT 500 // Timeout window in ms in which the double tap can occur.
 
-#define DYNAMIC_KEYMAP_LAYER_COUNT 16
 #define VIAL_TAP_DANCE_ENTRIES 50
 #define VIAL_TAP_COMBO_ENTRIES 50
 #define VIAL_COMBO_ENTRIES 50

--- a/keyboards/svalboard/info.json
+++ b/keyboards/svalboard/info.json
@@ -26,6 +26,9 @@
       "cols": ["GP14", "GP13", "GP12", "GP11", "GP10", "GP9"],
       "rows": ["GP8", "GP7", "GP6", "GP5", "GP4"]
   },
+  "dynamic_keymap": {
+      "layer_count": 16
+  },
   "mousekey": {
       "delay": 30,
       "move_delta": 1,


### PR DESCRIPTION
Previously we'd only been using 8k of the available flash
for our storage of vial elements.  That has been increased
to 64k.
    
We'd also previously only been using 2mb of the 16mb of flash
we have.  While not that useful right now, it should be later.