### PR TITLE
Split keymap.c into keymap.c and keymap_all.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,4 +115,4 @@ compile_commands.json
 .clangd/
 .cache/
 keyboards/svalboard/sweep_keymap.yaml
-keyboards/svalboard/keymaps/vial/keymap_all.h
+keyboards/svalboard/keymaps/**/keymap_all.h

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ compile_commands.json
 .clangd/
 .cache/
 keyboards/svalboard/sweep_keymap.yaml
+keyboards/svalboard/keymaps/vial/keymap_all.h

--- a/keyboards/svalboard/keymaps/vial/keymap.c
+++ b/keyboards/svalboard/keymaps/vial/keymap.c
@@ -81,6 +81,9 @@ enum layer {
     MBO = MH_AUTO_BUTTONS_LAYER,
 };
 
+#if __has_include("keymap_all.h")
+#include "keymap_all.h"
+#else
 const uint16_t PROGMEM keymaps[DYNAMIC_KEYMAP_LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS] = {
     [NORMAL] = LAYOUT(
         /*Center           North           East            South           West*/
@@ -167,6 +170,7 @@ const uint16_t PROGMEM keymaps[DYNAMIC_KEYMAP_LAYER_COUNT][MATRIX_ROWS][MATRIX_C
         )
 
 };
+#endif
 
 bool achordion_chord(uint16_t tap_hold_keycode, keyrecord_t* tap_hold_record,
                      uint16_t other_keycode, keyrecord_t* other_record) {


### PR DESCRIPTION
For easier development purposes:

Keybard now has a working `keymap_all.h` download, at https://captdeaf.github.io/keybard

This PR separates the actual keymap from `keymap.c`, placing it into `keymap_all.h`.

For easier development: Download your `keymap_all.h` from Keybard, plop down as a replacement to keyboards/`svalboard/keymaps/vial/keymap_all.h`, and any builds will have your keymap. Just be sure not to git add or git commit your `keymap_all.h` (unless you mean to!).

Note: Builds will not have macros, combos, etc. Just the keymap. Which for rapid development works just fine for me.

`keymap_all.h` download from keybard is just the straight-up qmk integers. Instead of KC_A, it's 4, etc. (Fastest way to get it working.