### PR TITLE
Use fresh_install and keymap_all.h now generates a function, sval_ini…

### DIFF
--- a/keyboards/svalboard/keymaps/vial/keymap.c
+++ b/keyboards/svalboard/keymaps/vial/keymap.c
@@ -182,18 +182,8 @@ void keyboard_post_init_user(void) {
   rgblight_layers = sval_rgb_layers;
 
 #if __has_include("keymap_all.h")
-  // Check if we've already got our macros set. At this point we're just
-  // seeing if ANY macro is defined.
-  if (sval_macro_size > 0) {
-    uint8_t get[DYNAMIC_KEYMAP_MACRO_COUNT];
-    uint8_t check[DYNAMIC_KEYMAP_MACRO_COUNT];
-
-    memset(check, 0, DYNAMIC_KEYMAP_MACRO_COUNT);
-    dynamic_keymap_macro_get_buffer(0, DYNAMIC_KEYMAP_MACRO_COUNT, get);
-    if (memcmp(get, check, DYNAMIC_KEYMAP_MACRO_COUNT) == 0) {
-      // We have a blank keymap. Copy ours over.
-      dynamic_keymap_macro_set_buffer(0, sval_macro_size, sval_macros);
-    }
+  if (fresh_install) {
+    sval_init_defaults();
   }
 #endif
 }

--- a/keyboards/svalboard/svalboard.c
+++ b/keyboards/svalboard/svalboard.c
@@ -4,6 +4,7 @@
 
 saved_values_t global_saved_values;
 const int16_t mh_timer_choices[4] = { 300, 500, 800, -1 }; // -1 is infinite.
+bool fresh_install = false;
 
 void write_eeprom_kb(void) {
     eeconfig_update_kb_datablock(&global_saved_values);
@@ -101,12 +102,18 @@ void set_right_dpi(uint8_t index) {
 }
 
 void set_dpi_from_eeprom(void) {
-    read_eeprom_kb();
     set_left_dpi(global_saved_values.left_dpi_index);
     set_right_dpi(global_saved_values.right_dpi_index);
 }
 
+// Called from via_init, we can check here if we're a fresh
+// installation.
+void via_init_kb(void) {
+  fresh_install = !via_eeprom_is_valid();
+}
+
 void keyboard_post_init_kb(void) {
+    read_eeprom_kb();
     set_dpi_from_eeprom();
     keyboard_post_init_user();
 }

--- a/keyboards/svalboard/svalboard.h
+++ b/keyboards/svalboard/svalboard.h
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "quantum.h"
 
 extern const int16_t mh_timer_choices[4];
+extern bool fresh_install;
 
 struct saved_values {
     uint8_t version;  // Currently at 1,  We assume all new data will be zeroed.


### PR DESCRIPTION
So there's one hook where we can figure out if it's a fresh install or not: `via_init_kb()`, on a fresh flashing of the hardware, has an invalid `via_eeprom`.

I've modified Keybard's keymap_all.h to generate a function, `sval_init_defaults()`, which is called to repopulate everything other than the keymaps. It works for macros, tap dances, combos, and key overrides.

Even if I need to add more features to keymap_all.h, `sval_init_defaults()` should handle it without any further changes to vial-qmk.