### PR TITLE
Fix typo in scroll toggle key description

### DIFF
--- a/keyboards/svalboard/keymaps/vial/vial.json
+++ b/keyboards/svalboard/keymaps/vial/vial.json
@@ -88,7 +88,7 @@
       },
       {
         "shortName": "Scroll\nToggle",
-        "title": "Togglle the pointer's scroll status.",
+        "title": "Toggle the pointer's scroll status.",
         "name": "SV_SCROLL_TOGGLE"
       },
       {


### PR DESCRIPTION
This got introduced in cd3f1e44f22 and I didn't catch it.