### PR TITLE
Enable steno with GeminiPR and combined keys

### DIFF
--- a/keyboards/svalboard/keymaps/vial/config.h
+++ b/keyboards/svalboard/keymaps/vial/config.h
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
+#define STENO_COMBINEDMAP
+
 #define VIAL_KEYBOARD_UID {0x1B, 0x18, 0x7D, 0xF2, 0x21, 0xF6, 0x29, 0x48}
 
 // Vial security combos, depending on which unit this is...

--- a/keyboards/svalboard/keymaps/vial/rules.mk
+++ b/keyboards/svalboard/keymaps/vial/rules.mk
@@ -2,4 +2,7 @@ VIA_ENABLE = yes
 VIAL_ENABLE = yes
 VIAL_INSECURE ?= yes
 
+STENO_ENABLE = yes
+STENO_PROTOCOL = geminipr
+
 SRC += ../features/achordion.c


### PR DESCRIPTION
Enables steno support over the GeminiPR protocol.

Also enables support for combined keys, e.g. `STN_AO`.