### PR TITLE
Automouse Toggle Support

### DIFF
--- a/keyboards/svalboard/keymaps/keymap_support.c
+++ b/keyboards/svalboard/keymaps/keymap_support.c
@@ -317,6 +317,10 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
             case SV_OUTPUT_STATUS:
                 output_keyboard_info();
                 return false;
+            case SV_TOGGLE_AUTOMOUSE:
+                global_saved_values.auto_mouse = !global_saved_values.auto_mouse;
+                write_eeprom_kb();
+                return false;
         }
     } else { // key released
         switch (keycode) {
@@ -383,14 +387,16 @@ void matrix_scan_kb(void) {
 }
 
 void mouse_mode(bool on) {
-    if (on) {
-        layer_on(MH_AUTO_BUTTONS_LAYER);
-        mh_auto_buttons_timer = timer_read();
-        mouse_mode_enabled = true;
-    } else {
-        layer_off(MH_AUTO_BUTTONS_LAYER);
-        mh_auto_buttons_timer = 0;
-        mouse_mode_enabled = false;
-        mouse_keys_pressed = 0;
+    if (global_saved_values.auto_mouse) {
+        if (on) {
+            layer_on(MH_AUTO_BUTTONS_LAYER);
+            mh_auto_buttons_timer = timer_read();
+            mouse_mode_enabled = true;
+        } else {
+            layer_off(MH_AUTO_BUTTONS_LAYER);
+            mh_auto_buttons_timer = 0;
+            mouse_mode_enabled = false;
+            mouse_keys_pressed = 0;
+        }
     }
 }

--- a/keyboards/svalboard/keymaps/keymap_support.c
+++ b/keyboards/svalboard/keymaps/keymap_support.c
@@ -319,11 +319,12 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                 output_keyboard_info();
                 return false;
             case SV_TOGGLE_AUTOMOUSE:
-                global_saved_values.auto_mouse = !global_saved_values.auto_mouse;
                 //if we disable automouse, manually kick out of mouse mode in case timer was running
-                if (!global_saved_values.auto_mouse) {
+                //needs to go first to avoid the lockout
+                if (global_saved_values.auto_mouse) {
                     mouse_mode(false);
                 }
+                global_saved_values.auto_mouse = !global_saved_values.auto_mouse;
                 write_eeprom_kb();
                 return false;
         }

--- a/keyboards/svalboard/keymaps/keymap_support.c
+++ b/keyboards/svalboard/keymaps/keymap_support.c
@@ -222,7 +222,8 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
 	                    keycode == SV_LEFT_SCROLL_TOGGLE || \
 		            keycode == SV_RIGHT_SCROLL_TOGGLE || \
 		            keycode == SV_TOGGLE_ACHORDION || \
-	                    keycode == SV_MH_CHANGE_TIMEOUTS)
+	                    keycode == SV_MH_CHANGE_TIMEOUTS || \
+                        keycode == SV_TOGGLE_AUTOMOUSE)
 
         uint16_t layer_keycode = keymap_key_to_keycode(MH_AUTO_BUTTONS_LAYER, record->event.key);
         if (BAD_KEYCODE_CONDITONAL ||
@@ -319,6 +320,10 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                 return false;
             case SV_TOGGLE_AUTOMOUSE:
                 global_saved_values.auto_mouse = !global_saved_values.auto_mouse;
+                //if we disable automouse, manually kick out of mouse mode in case timer was running
+                if (!global_saved_values.auto_mouse) {
+                    mouse_mode(false);
+                }
                 write_eeprom_kb();
                 return false;
         }

--- a/keyboards/svalboard/keymaps/keymap_support.h
+++ b/keyboards/svalboard/keymaps/keymap_support.h
@@ -40,6 +40,7 @@ enum my_keycodes {
     SV_SCROLL_HOLD,
     SV_SCROLL_TOGGLE,
     SV_OUTPUT_STATUS,
+    SV_TOGGLE_AUTOMOUSE,
     // New keycodes should go here, to avoid breaking existing keymaps - order must match vial.json
     KC_NORMAL_HOLD = SAFE_RANGE,
     KC_FUNC_HOLD,

--- a/keyboards/svalboard/keymaps/vial/keymap.c
+++ b/keyboards/svalboard/keymaps/vial/keymap.c
@@ -105,12 +105,12 @@ const uint16_t PROGMEM keymaps[DYNAMIC_KEYMAP_LAYER_COUNT][MATRIX_ROWS][MATRIX_C
         /* R2 */            KC_TRNS,            RGB_VAI,            KC_TRNS,            RGB_VAD,            KC_TRNS,            -1,
         /* R3 */            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            -1,
         /* R4 */            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            -1,
-        
+
         /* L1 */            SV_OUTPUT_STATUS,       KC_TRNS,             KC_TRNS,         KC_TRNS,            KC_TRNS,            -1,
         /* L2 */            SV_RIGHT_SCROLL_TOGGLE, SV_RIGHT_DPI_INC,    KC_TRNS,         SV_RIGHT_DPI_DEC,   KC_TRNS,            -1,
         /* L3 */            SV_LEFT_SCROLL_TOGGLE,  SV_LEFT_DPI_INC,     KC_TRNS,         SV_LEFT_DPI_DEC,    KC_TRNS,            -1,
-        /* L4 */            SV_MH_CHANGE_TIMEOUTS,  SV_TOGGLE_ACHORDION, KC_TRNS,         KC_TRNS,            KC_TRNS,            -1,
-        
+        /* L4 */            SV_MH_CHANGE_TIMEOUTS,  SV_TOGGLE_ACHORDION, KC_TRNS,         SV_TOGGLE_AUTOMOUSE,KC_TRNS,            -1,
+
         /*                  Down                Pad                 Up                  Nail                Knuckle             Double Down         */
         /* RT */            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,
         /* LT */            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS

--- a/keyboards/svalboard/keymaps/vial/vial.json
+++ b/keyboards/svalboard/keymaps/vial/vial.json
@@ -95,6 +95,11 @@
 	"shortName": "Output\nStatus",
 	"title": "Output the current internal state of the keyboard.",
 	"name": "SV_OUTPUT_STATUS"
+      },
+      {
+        "shortName": "AutoMouse\nToggle",
+        "title": "Toggle Auto Mouse layer activation.",
+        "name": "SV_TOGGLE_AUTOMOUSE"
       }
     ],
     "layouts": {

--- a/keyboards/svalboard/svalboard.c
+++ b/keyboards/svalboard/svalboard.c
@@ -49,6 +49,11 @@ void read_eeprom_kb(void) {
         global_saved_values.layer_colors[15] = HSV(0xD5FFFF); // Magenta
         modified = true;
     }
+    if (global_saved_values.version < 4) {
+        global_saved_values.version = 4;
+        global_saved_values.auto_mouse = true;
+        modified = true;
+    }
     // As we add versions, just append here.
     if (modified) {
         write_eeprom_kb();
@@ -79,8 +84,9 @@ void output_keyboard_info(void) {
 	    yes_or_no(global_saved_values.left_scroll), dpi_choices[global_saved_values.left_dpi_index],
 	    yes_or_no(global_saved_values.right_scroll), dpi_choices[global_saved_values.right_dpi_index]);
     send_string(output_buffer);
-    sprintf(output_buffer, "Achordion: %s, MH Keys Timer: %d\n",
+    sprintf(output_buffer, "Achordion: %s, MH Keys: %s, MH Keys Timer: %d\n",
 	    yes_or_no(!global_saved_values.disable_achordion),
+        yes_or_no(global_saved_values.auto_mouse),
 	    mh_timer_choices[global_saved_values.mh_timer_index]);
     send_string(output_buffer);
 }

--- a/keyboards/svalboard/svalboard.h
+++ b/keyboards/svalboard/svalboard.h
@@ -32,6 +32,7 @@ struct saved_values {
     bool left_scroll :1;
     bool right_scroll :1;
     bool disable_achordion: 1;
+    bool auto_mouse: 1;
     unsigned int unused0 :5;
     uint8_t left_dpi_index;
     uint8_t right_dpi_index;


### PR DESCRIPTION
This PR adds support for eeprom stored automouse activation settings, defaulting to true. Also adds a key to vial and the base keymap that toggles the setting and commits it to eeprom.