### PR TITLE
Fixed LED brightness issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        keyboard: [ svalboard/trackpoint, svalboard, svalboard/trackball/pmw3360, svalboard/trackball/pmw3389, svalboard/azoteq ]
+        keyboard: [ svalboard/trackball/pmw3389 ]
         keymap: [ vial ]
         side: [ left, right ]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        keyboard: [ svalboard/trackball/pmw3389 ]
+        keyboard: [ svalboard/trackpoint, svalboard, svalboard/trackball/pmw3360, svalboard/trackball/pmw3389, svalboard/azoteq ]
         keymap: [ vial ]
         side: [ left, right ]
 

--- a/keyboards/svalboard/svalboard.c
+++ b/keyboards/svalboard/svalboard.c
@@ -145,9 +145,9 @@ void sval_set_active_layer(uint32_t layer, bool save) {
     sval_active_layer = layer;
     struct layer_hsv cols = global_saved_values.layer_colors[layer];
     if (save) {
-        rgblight_sethsv(cols.hue, cols.sat, cols.val);
+        rgblight_sethsv(cols.hue, cols.sat, rgblight_get_val()); //store using current brightness
     } else {
-        rgblight_sethsv_noeeprom(cols.hue, cols.sat, cols.val);
+        rgblight_sethsv_noeeprom(cols.hue, cols.sat, rgblight_get_val()); //reuse currrent brightness
     }
 }
 
@@ -240,7 +240,7 @@ void raw_hid_receive_kb(uint8_t *data, uint8_t length) {
 
 void sval_on_reconnect(void) {
     // Reset colors, or it won't communicate the right color.
-    rgblight_sethsv_noeeprom(0, 0, 0);
+    rgblight_sethsv_noeeprom(0, 0, rgblight_get_val()); //reuse existing (eeprom) val, so brightness doesn't reset
     sval_set_active_layer(sval_active_layer, true);
 }
 #endif


### PR DESCRIPTION
Layer LED brightness is no longer reset to maximum on each layer change.

Users can set layer LED brightness using the RGB_VAI and RGB_VAD keycodes, and these changes will persist across power cycles.