### PR TITLE
[WIP] Add Layer Options and SetColor

### DIFF
--- a/keyboards/svalboard/config.h
+++ b/keyboards/svalboard/config.h
@@ -31,8 +31,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define FORCE_NKRO
 #define EE_HANDS
 //#define DEBUG_MATRIX_SCAN_RATE
-// Data size is 5 + (16 * 3), to include layer colors in HSV struct.
-#define EECONFIG_KB_DATA_SIZE 53
+// Data size is 6 + (16 * 3), to include layer colors in HSV struct.
+#define EECONFIG_KB_DATA_SIZE (6 + (16 * 3))
 
 #define FLASH_LEN (16 * 1024 * 1024)
 #define WEAR_LEVELING_BACKING_SIZE (128 * 1024)
@@ -87,7 +87,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //  https://docs.qmk.fm/#/feature_rgblight?id=configuration
 #define WS2812_DI_PIN GP19
 #define RGBLED_SPLIT { 1, 1 }
-#define RGBLIGHT_LAYERS_RETAIN_VAL
+// #define RGBLIGHT_LAYERS_RETAIN_VAL
 #define RGBLIGHT_LAYERS DYNAMIC_KEYMAP_LAYER_COUNT
 #define RGBLIGHT_DEFAULT_SAT 0 // white?
 #define RGBLIGHT_LIMIT_VAL 255

--- a/keyboards/svalboard/svalboard.c
+++ b/keyboards/svalboard/svalboard.c
@@ -56,6 +56,10 @@ void read_eeprom_kb(void) {
         global_saved_values.auto_mouse = true;
         modified = true;
     }
+    if (global_saved_values.version < 5) {
+        global_saved_values.version = 5;
+        global_saved_values.layer_options = 0;
+    }
     // As we add versions, just append here.
     if (modified) {
         write_eeprom_kb();
@@ -144,10 +148,14 @@ void sval_set_active_layer(uint32_t layer, bool save) {
     if (layer > 15) layer = 15;
     sval_active_layer = layer;
     struct layer_hsv cols = global_saved_values.layer_colors[layer];
+    uint8_t val = cols.val;
+    if (LAYER_OPTION_BACKLIGHT) {
+      val = rgblight_get_val();
+    }
     if (save) {
-        rgblight_sethsv(cols.hue, cols.sat, rgblight_get_val()); //store using current brightness
+        rgblight_sethsv(cols.hue, cols.sat, val); //store using current brightness
     } else {
-        rgblight_sethsv_noeeprom(cols.hue, cols.sat, rgblight_get_val()); //reuse currrent brightness
+        rgblight_sethsv_noeeprom(cols.hue, cols.sat, val); //reuse currrent brightness
     }
 }
 
@@ -234,6 +242,15 @@ void raw_hid_receive_kb(uint8_t *data, uint8_t length) {
                 write_eeprom_kb();
             }
             sval_set_active_layer(sval_active_layer, false);
+            break;
+        case sval_id_get_layer_options:
+            data[0] = global_saved_values.layer_options;
+            break;
+        case sval_id_set_layer_options:
+            global_saved_values.layer_options = data[2];
+            break;
+        case sval_id_set_color_hsv:
+            rgblight_sethsv(data[2], data[3], data[4]);
             break;
     }
 }

--- a/keyboards/svalboard/svalboard.h
+++ b/keyboards/svalboard/svalboard.h
@@ -38,9 +38,12 @@ struct saved_values {
     uint8_t right_dpi_index;
     uint8_t mh_timer_index;
     struct layer_hsv layer_colors[DYNAMIC_KEYMAP_LAYER_COUNT];
+    uint8_t layer_options;
 };
 
-#define SVAL_PROTO_VERSION 3
+#define LAYER_OPTION_BACKLIGHT (global_saved_values.layer_options & 1)
+
+#define SVAL_PROTO_VERSION 4
 
 #define SVAL_VIA_PREFIX 0xEE
 
@@ -50,6 +53,9 @@ enum sval_command_ids {
     // Layer HSVs
     sval_id_get_layer_hsv                        = 0x10,
     sval_id_set_layer_hsv                        = 0x11,
+    sval_id_get_layer_options                    = 0x12,
+    sval_id_set_layer_options                    = 0x13,
+    sval_id_set_color_hsv                        = 0x14,
 };
 
 // Just for ping pong, do we want anything else for it?


### PR DESCRIPTION
Adds layer options to sval commands.

Right now only one bit is being used.

Bit 0x01:
    Clear: Use keybard-configured V for HSV
    Set: Use qmk brightness, same V for all layers

Also adds set_color(h, s, v): Sets the sval colors to HSV. Temporarily, nothing is written to eeprom or flash.