### PR TITLE
updates default keymap with new NAVNAS/FUNC approach, and removes all TO() style layer usage

### DIFF
--- a/keyboards/svalboard/keymaps/vial/keymap.c
+++ b/keyboards/svalboard/keymaps/vial/keymap.c
@@ -35,10 +35,10 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
 enum layer {
     NORMAL,
+    NAVNAS,
     FUNC,
-    NAS,
-    BOARD_CONFIG,
-    MBO = MH_AUTO_BUTTONS_LAYER,
+    BOARD_CONFIG = (MH_AUTO_BUTTONS_LAYER - 1),
+    MBO = MH_AUTO_BUTTONS_LAYER
 };
 
 #if __has_include("keymap_all.h")
@@ -47,92 +47,100 @@ enum layer {
 int sval_macro_size = 0;
 uint8_t sval_macros[] = {0};
 const uint16_t PROGMEM keymaps[DYNAMIC_KEYMAP_LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS] = {
+    /* ===== NORMAL ===== */
     [NORMAL] = LAYOUT(
-        /*Center           North           East            South           West*/
-
-        /*R1*/ KC_J,            KC_U,           KC_QUOTE,       KC_M,           KC_H, XXXXXXX,
-        /*R2*/ KC_K,            KC_I,           KC_COLON,       KC_COMMA,       KC_Y, XXXXXXX,
-        /*R3*/ KC_L,            KC_O,           KC_LGUI,        KC_DOT,         KC_N, XXXXXXX,
-        /*R4*/ KC_SEMICOLON,    KC_P,           KC_BSLS,        KC_SLASH,       KC_RBRC, XXXXXXX,
-
-        /*L1*/ KC_F,            KC_R,           KC_G,           KC_V,           KC_DOUBLE_QUOTE, XXXXXXX,
-        /*L2*/ KC_D,            KC_E,           KC_T,           KC_C,           KC_GRAVE, XXXXXXX,
-        /*L3*/ KC_S,            KC_W,           KC_B,           KC_X,           KC_ESC, XXXXXXX,
-        /*L4*/ KC_A,            KC_Q,           KC_LBRC,        KC_Z,           KC_DEL, XXXXXXX,
-
-        /*     Down            Pad            Up             Nail           Knuckle    DoubleDown*/
-        /*RT*/ MO(NAS),         KC_SPACE,       TO(FUNC),       KC_BSPC,        KC_LALT,     XXXXXXX,
-        /*LT*/ KC_LSFT,         KC_ENTER,       TO(NORMAL),          KC_TAB,         KC_LCTL,     KC_CAPS
+        /*      Center           North               East                South                West                Double*/
+        /*R1*/ KC_J              , KC_U              , KC_QUOTE          , KC_M            , KC_H              , KC_NO           ,
+        /*R2*/ KC_K              , KC_I              , KC_COLON          , KC_COMMA        , KC_Y              , KC_NO             ,
+        /*R3*/ KC_L              , KC_O              , LT(BOARD_CONFIG, KC_NO)  , KC_DOT   , KC_N              , KC_NO           ,
+        /*R4*/ KC_SEMICOLON      , KC_P              , KC_BSLS           , KC_SLASH        , KC_RBRC           , KC_NO          ,
+        /*L1*/ KC_F              , KC_R              , KC_G              , KC_V            , LSFT(KC_QUOTE)    , KC_NO            ,
+        /*L2*/ KC_D              , KC_E              , KC_T              , KC_C            , KC_GRAVE          , KC_NO         ,
+        /*L3*/ KC_S              , KC_W              , KC_B              , KC_X            , KC_ESCAPE         , KC_NO           ,
+        /*L4*/ KC_A              , KC_Q              , KC_LBRC           , KC_Z            , KC_DELETE         , KC_NO           ,
+        
+        /*     Down                 Pad                Up                  Nail            Knuckle             DoubleDown*/
+        /*RT*/ MO(NAVNAS)          , KC_SPACE        , KC_NO             , KC_BSPC         , KC_LALT           , MO(FUNC)             ,
+        /*LT*/ KC_LSFT       , LT(NAVNAS, KC_ENTER)  , KC_NO             , LGUI_T(KC_TAB)  , KC_LCTL           , KC_CAPS       
         ),
 
+    [NAVNAS] = LAYOUT(
+        /*      Center           North               East                South                West                Double*/
+        /*R1*/ KC_LEFT           , KC_7              , LSFT(KC_MINUS)    , KC_HOME           , LSFT(KC_5)        , KC_NO             ,
+        /*R2*/ KC_UP             , KC_8              , KC_NO             , KC_PGUP           , LSFT(KC_6)        , KC_NO             ,
+        /*R3*/ KC_DOWN           , KC_NO             , KC_NO             , KC_PGDN           , KC_INSERT         , KC_NO             ,
+        /*R4*/ KC_RIGHT          , KC_PSCR           , KC_NO             , KC_END            , LSFT(KC_0)        , KC_NO             ,
+        /*L1*/ KC_4              , LSFT(KC_4)        , KC_5              , KC_9              , KC_MINUS          , KC_NO             ,
+        /*L2*/ KC_3              , LSFT(KC_3)        , KC_0              , KC_8              , KC_NO             , KC_NO             ,
+        /*L3*/ KC_2              , LSFT(KC_2)        , LSFT(KC_EQUAL)    , KC_7              , KC_NO             , KC_NO             ,
+        /*L4*/ KC_1              , LSFT(KC_1)        , LSFT(KC_9)        , KC_6              , KC_EQUAL          , KC_NO             ,
+        
+        /*     Down               Pad                Up                  Nail                Knuckle             DoubleDown */
+        /*RT*/ KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           ,
+        /*LT*/ KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           
+        ),
+    
+    /* ===== FUNCTION KEYS ===== */
     [FUNC] = LAYOUT(
-        /*Center           North           East            South           West*/
-        /*R1*/ KC_HOME,         KC_UP,          KC_RIGHT,       KC_DOWN,        KC_LEFT, XXXXXXX,
-        /*R2*/ XXXXXXX,         KC_F8,          XXXXXXX,        KC_F7,          KC_END, XXXXXXX,
-        /*R3*/ KC_PSCR,         KC_F10,         KC_LGUI,        KC_F9,          KC_INS, XXXXXXX,
-        /*R4*/ KC_PAUSE,        KC_PGUP,        KC_F12,         KC_PGDN,        KC_F11, XXXXXXX,
-
-        /*L1*/ KC_HOME,         KC_UP,          KC_RIGHT,       KC_DOWN,        KC_LEFT, XXXXXXX,
-        /*L2*/ XXXXXXX,         KC_F6,          XXXXXXX,        KC_F5,          XXXXXXX, XXXXXXX,
-        /*L3*/ XXXXXXX,         KC_F4,          XXXXXXX,        KC_F3,          KC_ESC, XXXXXXX,
-        /*L4*/ TO(BOARD_CONFIG), KC_F2,         XXXXXXX,        KC_F1,          KC_DEL, XXXXXXX,
-
-        /*     Down            Pad            Up             Nail           Knuckle    DoubleDown*/
-        /*RT*/ MO(NAS),         KC_SPACE,       _______,       KC_BSPC,      KC_LALT, _______,
-        /*LT*/ KC_LSFT,       KC_ENTER,         _______, KC_TAB,         KC_LCTL, _______
-        ),
-
-    [NAS] = LAYOUT(
-        /*Center           North           East            South           West*/
-        /*R1*/ KC_7,            KC_AMPR,        KC_UNDS,        KC_KP_PLUS,     KC_6, XXXXXXX,
-        /*R2*/ KC_8,            KC_KP_ASTERISK, KC_COLON,       KC_COMMA,       KC_CIRCUMFLEX, XXXXXXX,
-        /*R3*/ KC_9,            KC_LPRN,        KC_LGUI,        KC_DOT,         KC_SEMICOLON, XXXXXXX,
-        /*R4*/ KC_0,            KC_RPRN,        XXXXXXX,        KC_QUES,        KC_RBRC, XXXXXXX,
-
-        /*L1*/ KC_4,            KC_DOLLAR,      KC_5,           KC_MINUS,       KC_SLASH, XXXXXXX,
-        /*L2*/ KC_3,            KC_HASH,        KC_GT,          KC_PERCENT,     KC_LT, XXXXXXX,
-        /*L3*/ KC_2,            KC_AT,          XXXXXXX,        KC_X,           KC_ESC, XXXXXXX,
-        /*L4*/ KC_1,            KC_EXCLAIM,     KC_TILDE,       KC_EQUAL,       KC_DEL, XXXXXXX,
-
-        /*     Down            Pad            Up             Nail           Knuckle    DoubleDown*/
-        /*RT*/ MO(NAS),         KC_SPACE,       _______,       KC_BSPC,        KC_LALT, _______,
-        /*LT*/ KC_LSFT,         KC_ENTER,       _______,        KC_TAB,         KC_LCTL, _______
+        /*      Center           North               East                South                West                Double*/
+        /*R1*/ KC_F7             , KC_F21            , KC_F16            , KC_F17            , KC_F6             , KC_NO             ,
+        /*R2*/ KC_F8             , KC_F22            , KC_NO             , KC_F18            , KC_NO             , KC_NO             ,
+        /*R3*/ KC_F9             , KC_F23            , KC_NO             , KC_F19            , KC_NO             , KC_NO             ,
+        /*R4*/ KC_F10            , KC_F24            , KC_NO             , KC_F20            , KC_NO             , KC_NO             ,
+        /*L1*/ KC_F4             , KC_F14            , KC_F5             , KC_F9             , KC_F15            , KC_NO             ,
+        /*L2*/ KC_F3             , KC_F13            , KC_F10            , KC_F8             , KC_NO             , KC_NO             ,
+        /*L3*/ KC_F2             , KC_F12            , KC_NO             , KC_F7             , KC_NO             , KC_NO             ,
+        /*L4*/ KC_F1             , KC_F11            , KC_NO             , KC_F6             , KC_NO             , KC_NO             ,
+        
+        /*Down             Pad             Up              Nail            Knuckle         DoubleDown*/
+        /*RT*/ KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           ,
+        /*LT*/ KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           
         ),
 
     [BOARD_CONFIG] = LAYOUT(
-        /*                  Center              North               East                South               West                (XXX)               */
-        /* R1 */            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            -1,
-        /* R2 */            KC_TRNS,            RGB_VAI,            KC_TRNS,            RGB_VAD,            KC_TRNS,            -1,
-        /* R3 */            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            -1,
-        /* R4 */            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            -1,
+        /*         Center              North               East                South               West                (XXX)               */
+        /*R1*/     KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_NO,
+        /*R2*/     KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_NO,
+        /*R3*/     KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_NO,
+        /*R4*/     KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_NO,
+        /*L1*/     SV_OUTPUT_STATUS,   KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_NO,
+        /*L2*/     KC_TRNS,            SV_RIGHT_DPI_INC,   KC_TRNS,            SV_RIGHT_DPI_DEC,   KC_TRNS,            KC_NO,
+        /*L3*/     KC_TRNS,            SV_LEFT_DPI_INC,    KC_TRNS,            SV_LEFT_DPI_DEC,    KC_TRNS,            KC_NO,
+        /*L4*/     KC_TRNS,            KC_TRNS, KC_TRNS,   KC_TRNS,            KC_TRNS,            KC_NO,
 
-        /* L1 */            SV_OUTPUT_STATUS,       KC_TRNS,             KC_TRNS,         KC_TRNS,            KC_TRNS,            -1,
-        /* L2 */            SV_RIGHT_SCROLL_TOGGLE, SV_RIGHT_DPI_INC,    KC_TRNS,         SV_RIGHT_DPI_DEC,   KC_TRNS,            -1,
-        /* L3 */            SV_LEFT_SCROLL_TOGGLE,  SV_LEFT_DPI_INC,     KC_TRNS,         SV_LEFT_DPI_DEC,    KC_TRNS,            -1,
-        /* L4 */            SV_MH_CHANGE_TIMEOUTS,  SV_AXIS_SCROLL_LOCK, KC_TRNS,         KC_NO,              KC_TRNS,            -1,
-
-        /*                  Down                Pad                 Up                  Nail                Knuckle             Double Down         */
-        /* RT */            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,
-        /* LT */            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS
+        /*        Down                Pad                 Up                  Nail                Knuckle             Double Down         */
+        /* RT */  KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,
+        /* LT */  KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS,            KC_TRNS
       ),
 
+    /* ===== MBO ===== */
     [MBO] = LAYOUT(
-        /*Center           North           East            South           West*/
-        /*R1*/ KC_BTN1,        KC_TRNS,       KC_TRNS,       KC_TRNS,       KC_TRNS, XXXXXXX,
-        /*R2*/ KC_BTN3,        KC_TRNS,       KC_TRNS,       KC_TRNS,       KC_TRNS, XXXXXXX,
-        /*R3*/ KC_BTN2,        KC_TRNS,       KC_TRNS,       KC_TRNS,       KC_TRNS, XXXXXXX,
-        /*R4*/ SV_RECALIBRATE_POINTER,        KC_TRNS,       KC_TRNS,       KC_TRNS,       KC_TRNS, XXXXXXX,
-        /*L1*/ KC_BTN1,        KC_TRNS,       KC_TRNS,       KC_TRNS,        KC_TRNS, XXXXXXX,
-        /*L2*/ KC_BTN3,        KC_TRNS,       KC_TRNS,       SV_SNIPER_2,        KC_TRNS, XXXXXXX,
-        /*L3*/ KC_BTN2,        KC_TRNS,       KC_TRNS,       SV_SNIPER_3,        KC_TRNS, XXXXXXX,
-        /*L4*/ SV_RECALIBRATE_POINTER, KC_TRNS, KC_TRNS,       SV_SNIPER_5,      KC_TRNS, XXXXXXX,
-        /*     Down            Pad            Up             Nail           Knuckle    DoubleDown*/
-        /*RT*/ KC_TRNS,        KC_BTN1,       KC_TRNS,       KC_BTN2,       KC_TRNS,   KC_TRNS,
-        /*LT*/ KC_TRNS,        KC_BTN1,       KC_TRNS,       KC_BTN2,       KC_TRNS,   KC_TRNS
-        )
-
+        /*      Center           North               East                South                West                Double*/
+        /*R1*/ KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_NO             ,
+        /*R2*/ KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_NO             ,
+        /*R3*/ KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_NO             ,
+        /*R4*/ KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_NO             ,
+        /*L1*/ KC_BTN1           , KC_TRNS           , KC_TRNS           , LCTL(KC_V)        , KC_NO             , KC_NO             ,
+        /*L2*/ KC_BTN3           , KC_TRNS           , KC_TRNS           , LCTL(KC_C)        , KC_NO             , KC_NO             ,
+        /*L3*/ KC_BTN2           , KC_TRNS           , KC_TRNS           , LCTL(KC_X)        , KC_TRNS           , KC_NO             ,
+        /*L4*/ KC_TRNS           , KC_TRNS           , KC_TRNS           , SV_SNIPER_3       , KC_TRNS           , KC_NO             ,
+        
+        /*     Down               Pad                Up                  Nail                Knuckle             DoubleDown */
+        /*RT*/ KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           , KC_TRNS           ,
+        /*LT*/ KC_TRNS           , KC_BTN1           , KC_TRNS           , KC_BTN2           , KC_TRNS           , KC_TRNS          
+        ),
 };
 #endif
+
+bool achordion_chord(uint16_t tap_hold_keycode, keyrecord_t* tap_hold_record,
+                     uint16_t other_keycode, keyrecord_t* other_record) {
+    if (tap_hold_record->event.key.row == 0 || tap_hold_record->event.key.row == 5 ||
+        other_record->event.key.row    == 0 || other_record->event.key.row    == 5) {
+        return true;
+    }
+
+    return achordion_opposite_hands(tap_hold_record, other_record);
+}
 
 void keyboard_post_init_user(void) {
   // Customise these values if you need to debug the matrix

--- a/keyboards/svalboard/keymaps/vial/keymap.c
+++ b/keyboards/svalboard/keymaps/vial/keymap.c
@@ -37,8 +37,8 @@ enum layer {
     NORMAL,
     NAVNAS,
     FUNC,
-    BOARD_CONFIG = (MH_AUTO_BUTTONS_LAYER - 1),
-    MBO = MH_AUTO_BUTTONS_LAYER
+    BOARD_CONFIG,
+    MBO = MH_AUTO_BUTTONS_LAYER,
 };
 
 #if __has_include("keymap_all.h")
@@ -131,16 +131,6 @@ const uint16_t PROGMEM keymaps[DYNAMIC_KEYMAP_LAYER_COUNT][MATRIX_ROWS][MATRIX_C
         ),
 };
 #endif
-
-bool achordion_chord(uint16_t tap_hold_keycode, keyrecord_t* tap_hold_record,
-                     uint16_t other_keycode, keyrecord_t* other_record) {
-    if (tap_hold_record->event.key.row == 0 || tap_hold_record->event.key.row == 5 ||
-        other_record->event.key.row    == 0 || other_record->event.key.row    == 5) {
-        return true;
-    }
-
-    return achordion_opposite_hands(tap_hold_record, other_record);
-}
 
 void keyboard_post_init_user(void) {
   // Customise these values if you need to debug the matrix

--- a/keyboards/svalboard/keymaps/vial/keymap.c
+++ b/keyboards/svalboard/keymaps/vial/keymap.c
@@ -71,8 +71,8 @@ const uint16_t PROGMEM keymaps[DYNAMIC_KEYMAP_LAYER_COUNT][MATRIX_ROWS][MATRIX_C
         /*R3*/ KC_DOWN           , KC_NO             , KC_NO             , KC_PGDN           , KC_INSERT         , KC_NO             ,
         /*R4*/ KC_RIGHT          , KC_PSCR           , KC_NO             , KC_END            , LSFT(KC_0)        , KC_NO             ,
         /*L1*/ KC_4              , LSFT(KC_4)        , KC_5              , KC_9              , KC_MINUS          , KC_NO             ,
-        /*L2*/ KC_3              , LSFT(KC_3)        , KC_0              , KC_8              , KC_NO             , KC_NO             ,
-        /*L3*/ KC_2              , LSFT(KC_2)        , LSFT(KC_EQUAL)    , KC_7              , KC_NO             , KC_NO             ,
+        /*L2*/ KC_3              , LSFT(KC_3)        , KC_0              , KC_8              , KC_DOT            , KC_NO             ,
+        /*L3*/ KC_2              , LSFT(KC_2)        , LSFT(KC_EQUAL)    , KC_7              , KC_COMMA          , KC_NO             ,
         /*L4*/ KC_1              , LSFT(KC_1)        , LSFT(KC_9)        , KC_6              , KC_EQUAL          , KC_NO             ,
         
         /*     Down               Pad                Up                  Nail                Knuckle             DoubleDown */

--- a/keyboards/svalboard/keymaps/vial/keymap.c
+++ b/keyboards/svalboard/keymaps/vial/keymap.c
@@ -47,7 +47,7 @@ enum layer {
 int sval_macro_size = 0;
 uint8_t sval_macros[] = {0};
 const uint16_t PROGMEM keymaps[DYNAMIC_KEYMAP_LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS] = {
-    /* ===== NORMAL ===== */
+    /* ===== NORMAL ===== . */
     [NORMAL] = LAYOUT(
         /*      Center           North               East                South                West                Double*/
         /*R1*/ KC_J              , KC_U              , KC_QUOTE          , KC_M            , KC_H              , KC_NO           ,

--- a/keyboards/svalboard/keymaps/vial/keymap.c
+++ b/keyboards/svalboard/keymaps/vial/keymap.c
@@ -66,8 +66,8 @@ const uint16_t PROGMEM keymaps[DYNAMIC_KEYMAP_LAYER_COUNT][MATRIX_ROWS][MATRIX_C
 
     [NAVNAS] = LAYOUT(
         /*      Center           North               East                South                West                Double*/
-        /*R1*/ KC_LEFT           , KC_7              , LSFT(KC_MINUS)    , KC_HOME           , LSFT(KC_5)        , KC_NO             ,
-        /*R2*/ KC_UP             , KC_8              , KC_NO             , KC_PGUP           , LSFT(KC_6)        , KC_NO             ,
+        /*R1*/ KC_LEFT           , KC_7              , LSFT(KC_MINUS)    , KC_HOME           , KC_MINUS           , KC_NO             ,
+        /*R2*/ KC_UP             , KC_8              , LSFT(KC_5)        , KC_PGUP           , LSFT(KC_6)        , KC_NO             ,
         /*R3*/ KC_DOWN           , KC_NO             , KC_NO             , KC_PGDN           , KC_INSERT         , KC_NO             ,
         /*R4*/ KC_RIGHT          , KC_PSCR           , KC_NO             , KC_END            , LSFT(KC_0)        , KC_NO             ,
         /*L1*/ KC_4              , LSFT(KC_4)        , KC_5              , KC_9              , KC_MINUS          , KC_NO             ,

--- a/keyboards/svalboard/keymaps/vial/keymap.c
+++ b/keyboards/svalboard/keymaps/vial/keymap.c
@@ -47,7 +47,7 @@ enum layer {
 int sval_macro_size = 0;
 uint8_t sval_macros[] = {0};
 const uint16_t PROGMEM keymaps[DYNAMIC_KEYMAP_LAYER_COUNT][MATRIX_ROWS][MATRIX_COLS] = {
-    /* ===== NORMAL ===== . */
+    /* ===== NORMAL ===== */
     [NORMAL] = LAYOUT(
         /*      Center           North               East                South                West                Double*/
         /*R1*/ KC_J              , KC_U              , KC_QUOTE          , KC_M            , KC_H              , KC_NO           ,


### PR DESCRIPTION
This updates the default keymap in a major way -- homerow nav, left hand numpad, and only two primary layers.
Frees up both Up keys for user preference, as well as many duplicate keys no longer called for on NAVNAS -- should be a much better foundation for users to develop their own preferences, and no more confused users getting stuck on BOARD_CONFIG layer.  That layer is now accessed via Layer Tap on right ring east, and has been stripped to DPI only and Output Status to reduce onboarding confusion.