### PR TITLE
azoteq: Slow down the reporting rate on Azoteq.

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/qmk/qmk_cli
+    container: ghcr.io/qmk/qmk_cli@sha256:2dc05fc9f32efebd6b05c2b8676ee548358bc7e151e9dbf4dac6b6eed4513b07
 
     steps:
     - name: Checkout code - Non PR
@@ -79,9 +79,9 @@ jobs:
       shell: bash
 
     - name: Release
-      uses: softprops/action-gh-release@v2
+      uses: ncipollo/release-action@v1.11.2
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       with:
-        files: |
-          ${{ steps.move_file.outputs.file_name }}
+        allowUpdates: True
+        artifacts: "${{ steps.move_file.outputs.file_name }}"
 

--- a/keyboards/svalboard/azoteq/azoteq.c
+++ b/keyboards/svalboard/azoteq/azoteq.c
@@ -2,13 +2,24 @@
 #include "pointing_device.h"
 #include "pointing_device_internal.h"
 #include "axis_scale.h"
+#include "svalboard.h"
+
+// Azo can only report at 100hz.  Any faster is trouble.
+#define AZO_MS 10 
 
 extern const pointing_device_driver_t *real_device_driver;
 
+static uint16_t azo_timer = 0;
+static uint8_t azo_held_buttons = 0;
 
 report_mouse_t pointing_device_driver_get_report(report_mouse_t mouse_report) {
+    if (timer_elapsed(azo_timer) > AZO_MS) {
+        azo_timer = timer_read();
+        mouse_report        = real_device_driver->get_report(mouse_report);
+        azo_held_buttons = mouse_report.buttons;
+    }
 
-    mouse_report = real_device_driver->get_report(mouse_report);
+    mouse_report.buttons = azo_held_buttons;
 
     return mouse_report;
 }

--- a/keyboards/svalboard/azoteq/azoteq.c
+++ b/keyboards/svalboard/azoteq/azoteq.c
@@ -5,15 +5,16 @@
 #include "svalboard.h"
 
 // Azo can only report at 100hz.  Any faster is trouble.
-#define AZO_MS 10 
+#define AZO_MS 10
 
 extern const pointing_device_driver_t *real_device_driver;
 
 static uint16_t azo_timer = 0;
 static uint8_t azo_held_buttons = 0;
+static uint16_t azo_cached_cpi = 0;
 
 report_mouse_t pointing_device_driver_get_report(report_mouse_t mouse_report) {
-    if (timer_elapsed(azo_timer) > AZO_MS) {
+    if (timer_elapsed(azo_timer) >= AZO_MS) {
         azo_timer = timer_read();
         mouse_report        = real_device_driver->get_report(mouse_report);
         azo_held_buttons = mouse_report.buttons;
@@ -22,4 +23,15 @@ report_mouse_t pointing_device_driver_get_report(report_mouse_t mouse_report) {
     mouse_report.buttons = azo_held_buttons;
 
     return mouse_report;
+}
+
+uint16_t pointing_device_driver_get_cpi(void) {
+    return azo_cached_cpi;
+}
+
+void pointing_device_driver_set_cpi(uint16_t cpi) {
+    if (cpi != azo_cached_cpi) {
+        real_device_driver->set_cpi(cpi);
+        azo_cached_cpi = cpi;
+    }
 }

--- a/keyboards/svalboard/trackball/trackball.c
+++ b/keyboards/svalboard/trackball/trackball.c
@@ -4,6 +4,8 @@
 
 extern const pointing_device_driver_t *real_device_driver;
 
+static uint16_t trackball_cached_cpi = 0;
+
 report_mouse_t pointing_device_driver_get_report(report_mouse_t mouse_report) {
     int16_t swap;
 
@@ -14,4 +16,15 @@ report_mouse_t pointing_device_driver_get_report(report_mouse_t mouse_report) {
     mouse_report.y = -swap;
 
     return mouse_report;
+}
+
+uint16_t pointing_device_driver_get_cpi(void) {
+    return trackball_cached_cpi;
+}
+
+void pointing_device_driver_set_cpi(uint16_t cpi) {
+    if (cpi != trackball_cached_cpi) {
+        real_device_driver->set_cpi(cpi);
+        trackball_cached_cpi = cpi;
+    }
 }


### PR DESCRIPTION
There's some minor complications with making sure that the held buttons are reported correctly, but other than that the code keeps azoteq touchpads at under 100hz.

Minor fix to ci-cd matching upstream.

Fix to the release code for CI/CD.