### PR TITLE
Fix 'externally-managed-environment' error in build-firmware workflow

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         git config --global --add safe.directory '*'
         # Ensure all requirements got installed and qmk is sure it is set up
-        /usr/bin/python3 -m pip install -r /__w/vial-qmk/vial-qmk/requirements.txt
+        pip install -r /__w/vial-qmk/vial-qmk/requirements.txt
         qmk setup -y
         # Run make
         make ${{ inputs.keyboard }}/${{ inputs.side }}:${{ inputs.keymap }}


### PR DESCRIPTION
What this patch changes:

- In build-firmware.yml, use the `pip` executable available on the PATH to install vial-qmk's python dependencies. This `pip` executable is from the virtualenv of the `qmk` cli

Why:

Since last December, the workflow [started failing](https://github.com/svalboard/vial-qmk/actions/runs/20398427348/job/58617239480) on this line:

```sh
   /usr/bin/python3 -m pip install -r /__w/vial-qmk/vial-qmk/requirements.txt
```

with this error:

```
× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
...
```

I haven't tracked down the full causal chain, but I guess the immediate trigger was [qmk-cli's new release](https://github.com/qmk/qmk_cli/releases/tag/1.2.0) that uses a new installer script that defaults to [python 3.14](https://github.com/qmk/qmk_firmware/blob/38815db760f24268561f7fd138f1094d546b4f13/util/env-bootstrap.sh#L538).

I don't fully understand which site-packages directory/virtualenv these requirements need to be installed into, but if the qmk cli's one will do, the `pip` executable [made available on the PATH](https://github.com/qmk/qmk_cli/blob/1.2.0/Dockerfile#L30) looks suitable.

```sh
$ docker run --rm -it ghcr.io/qmk/qmk_cli
[...]
# which qmk
/opt/uv/tools/qmk/bin/qmk
# ls -d /opt/uv/tools/qmk/lib/python3.14/site-packages/*.dist-info | head -n 3
/opt/uv/tools/qmk/lib/python3.14/site-packages/argcomplete-3.6.3.dist-info
/opt/uv/tools/qmk/lib/python3.14/site-packages/attrs-25.4.0.dist-info
/opt/uv/tools/qmk/lib/python3.14/site-packages/colorama-0.4.6.dist-info
# which pip
/opt/uv/tools/qmk/bin/pip
```
