### PR TITLE
Add keycodes for left and right clicks with mouse layer exit on keyup

### DIFF
--- a/keyboards/svalboard/keymaps/blank/keymap.c
+++ b/keyboards/svalboard/keymaps/blank/keymap.c
@@ -58,7 +58,9 @@ layer_state_t default_layer_state_set_user(layer_state_t state) {
 void release_app_switch_gui(void);
 
 layer_state_t layer_state_set_user(layer_state_t state) {
-  release_app_switch_gui();
+  if (get_highest_layer(state) < get_highest_layer(layer_state)) {
+    release_app_switch_gui();
+  }
   for (int i = 0; i < RGBLIGHT_LAYERS; ++i) {
       rgblight_set_layer_state(i, layer_state_cmp(state, i));
   }

--- a/keyboards/svalboard/keymaps/blank/keymap.c
+++ b/keyboards/svalboard/keymaps/blank/keymap.c
@@ -55,7 +55,10 @@ layer_state_t default_layer_state_set_user(layer_state_t state) {
   return state;
 }
 
+void release_app_switch_gui(void);
+
 layer_state_t layer_state_set_user(layer_state_t state) {
+  release_app_switch_gui();
   for (int i = 0; i < RGBLIGHT_LAYERS; ++i) {
       rgblight_set_layer_state(i, layer_state_cmp(state, i));
   }

--- a/keyboards/svalboard/keymaps/blank/vial.json
+++ b/keyboards/svalboard/keymaps/blank/vial.json
@@ -105,6 +105,16 @@
 	 "shortName": "Turbo\nScan",
 	 "title": "Change the scan mode of the keyboard.",
 	 "name": "SV_TURBO_SCAN"
+      },
+      {
+        "shortName": "Mouse 1\nExit",
+        "title": "Left click and exit mouse layer on release.",
+        "name": "SV_MS_BTN1_EXIT"
+      },
+      {
+        "shortName": "Mouse 2\nExit",
+        "title": "Right click and exit mouse layer on release.",
+        "name": "SV_MS_BTN2_EXIT"
       }
     ],
     "layouts": {

--- a/keyboards/svalboard/keymaps/blank/vial.json
+++ b/keyboards/svalboard/keymaps/blank/vial.json
@@ -115,6 +115,11 @@
         "shortName": "Mouse 2\nExit",
         "title": "Right click and exit mouse layer on release.",
         "name": "SV_MS_BTN2_EXIT"
+      },
+      {
+        "shortName": "App\nSwitch",
+        "title": "Cmd+Tab app switching. Cmd releases on layer change.",
+        "name": "SV_APP_SWITCH"
       }
     ],
     "layouts": {

--- a/keyboards/svalboard/keymaps/keymap_support.c
+++ b/keyboards/svalboard/keymaps/keymap_support.c
@@ -98,6 +98,7 @@ bool enable_scale_5 = false;
 static bool scroll_hold    = false,
             scroll_toggle  = false;
 
+static bool app_switch_gui_held = false;
 
 #define AXIS_LOCK_BREAKAWAY_THRESHOLD 18750
 #define AXIS_LOCK_ENGAGE_THRESHOLD 6250
@@ -314,6 +315,13 @@ void check_layer_67(void) {
     }
 }
 
+void release_app_switch_gui(void) {
+    if (app_switch_gui_held) {
+        unregister_code(KC_LGUI);
+        app_switch_gui_held = false;
+    }
+}
+
 bool in_mod_tap = false;
 int8_t in_mod_tap_layer = -1;
 int8_t mouse_keys_pressed = 0;
@@ -473,6 +481,11 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
             case SV_MS_BTN2_EXIT:
                 register_code(KC_MS_BTN2);
                 return false;
+            case SV_APP_SWITCH:
+                register_code(KC_LGUI);
+                register_code(KC_TAB);
+                app_switch_gui_held = true;
+                return false;
         }
     } else { // key released
         switch (keycode) {
@@ -512,6 +525,9 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
             case SV_MS_BTN2_EXIT:
                 unregister_code(KC_MS_BTN2);
                 mouse_mode(false);
+                return false;
+            case SV_APP_SWITCH:
+                unregister_code(KC_TAB);
                 return false;
         }
     }

--- a/keyboards/svalboard/keymaps/keymap_support.c
+++ b/keyboards/svalboard/keymaps/keymap_support.c
@@ -467,6 +467,12 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
 	    case SV_TURBO_SCAN:
 	        change_turbo_scan();
 	        return false;
+            case SV_MS_BTN1_EXIT:
+                register_code(KC_MS_BTN1);
+                return false;
+            case SV_MS_BTN2_EXIT:
+                register_code(KC_MS_BTN2);
+                return false;
         }
     } else { // key released
         switch (keycode) {
@@ -498,6 +504,14 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                 return false;
             case SV_SCROLL_TOGGLE:
                 scroll_toggle ^= true;
+                return false;
+            case SV_MS_BTN1_EXIT:
+                unregister_code(KC_MS_BTN1);
+                mouse_mode(false);
+                return false;
+            case SV_MS_BTN2_EXIT:
+                unregister_code(KC_MS_BTN2);
+                mouse_mode(false);
                 return false;
         }
     }

--- a/keyboards/svalboard/keymaps/keymap_support.c
+++ b/keyboards/svalboard/keymaps/keymap_support.c
@@ -483,7 +483,8 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                 return false;
             case SV_APP_SWITCH:
                 register_code(KC_LGUI);
-                register_code(KC_TAB);
+                wait_ms(5);
+                tap_code(KC_TAB);
                 app_switch_gui_held = true;
                 return false;
         }
@@ -527,7 +528,6 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                 mouse_mode(false);
                 return false;
             case SV_APP_SWITCH:
-                unregister_code(KC_TAB);
                 return false;
         }
     }

--- a/keyboards/svalboard/keymaps/keymap_support.h
+++ b/keyboards/svalboard/keymaps/keymap_support.h
@@ -44,6 +44,7 @@ enum my_keycodes {
     SV_TURBO_SCAN,
     SV_MS_BTN1_EXIT,
     SV_MS_BTN2_EXIT,
+    SV_APP_SWITCH,
     KC_NORMAL_HOLD = SAFE_RANGE,
     KC_FUNC_HOLD,
     SV_SAFE_RANGE, // Keycodes over this are safe on Svalboard.

--- a/keyboards/svalboard/keymaps/keymap_support.h
+++ b/keyboards/svalboard/keymaps/keymap_support.h
@@ -42,6 +42,8 @@ enum my_keycodes {
     SV_OUTPUT_STATUS,
     SV_TOGGLE_AUTOMOUSE,
     SV_TURBO_SCAN,
+    SV_MS_BTN1_EXIT,
+    SV_MS_BTN2_EXIT,
     KC_NORMAL_HOLD = SAFE_RANGE,
     KC_FUNC_HOLD,
     SV_SAFE_RANGE, // Keycodes over this are safe on Svalboard.

--- a/keyboards/svalboard/keymaps/vial/keymap.c
+++ b/keyboards/svalboard/keymaps/vial/keymap.c
@@ -31,7 +31,9 @@ layer_state_t default_layer_state_set_user(layer_state_t state) {
 void release_app_switch_gui(void);
 
 layer_state_t layer_state_set_user(layer_state_t state) {
-  release_app_switch_gui();
+  if (get_highest_layer(state) < get_highest_layer(layer_state)) {
+    release_app_switch_gui();
+  }
   sval_set_active_layer(get_highest_layer(state), false);
   return state;
 }

--- a/keyboards/svalboard/keymaps/vial/keymap.c
+++ b/keyboards/svalboard/keymaps/vial/keymap.c
@@ -28,7 +28,10 @@ layer_state_t default_layer_state_set_user(layer_state_t state) {
   return state;
 }
 
+void release_app_switch_gui(void);
+
 layer_state_t layer_state_set_user(layer_state_t state) {
+  release_app_switch_gui();
   sval_set_active_layer(get_highest_layer(state), false);
   return state;
 }

--- a/keyboards/svalboard/keymaps/vial/vial.json
+++ b/keyboards/svalboard/keymaps/vial/vial.json
@@ -105,6 +105,16 @@
 	 "shortName": "Turbo\nScan",
 	 "title": "Change the scan mode of the keyboard.",
 	 "name": "SV_TURBO_SCAN"
+      },
+      {
+        "shortName": "Mouse 1\nExit",
+        "title": "Left click and exit mouse layer on release.",
+        "name": "SV_MS_BTN1_EXIT"
+      },
+      {
+        "shortName": "Mouse 2\nExit",
+        "title": "Right click and exit mouse layer on release.",
+        "name": "SV_MS_BTN2_EXIT"
       }
     ],
     "layouts": {

--- a/keyboards/svalboard/keymaps/vial/vial.json
+++ b/keyboards/svalboard/keymaps/vial/vial.json
@@ -115,6 +115,11 @@
         "shortName": "Mouse 2\nExit",
         "title": "Right click and exit mouse layer on release.",
         "name": "SV_MS_BTN2_EXIT"
+      },
+      {
+        "shortName": "App\nSwitch",
+        "title": "Cmd+Tab app switching. Cmd releases on layer change.",
+        "name": "SV_APP_SWITCH"
       }
     ],
     "layouts": {


### PR DESCRIPTION
Introduce SV_MS_BTN1_EXIT and SV_MS_BTN2_EXIT keycodes to allow left and right mouse clicks, respectively, with an exit from the mouse layer on release. Update keymap support files accordingly.

I find these keycodes to be a very useful alternative to mouse layer timeout that works more predictably.