### PR TITLE
Revert Azoteq November tweaks to baseline for new user accessibility.

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/qmk/qmk_cli
+    container: ghcr.io/qmk/qmk_cli@sha256:2dc05fc9f32efebd6b05c2b8676ee548358bc7e151e9dbf4dac6b6eed4513b07
 
     steps:
     - name: Checkout code - Non PR
@@ -79,9 +79,8 @@ jobs:
       shell: bash
 
     - name: Release
-      uses: softprops/action-gh-release@v2
+      uses: ncipollo/release-action@v1.11.2
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       with:
-        files: |
-          ${{ steps.move_file.outputs.file_name }}
-
+        allowUpdates: True
+        artifacts: "${{ steps.move_file.outputs.file_name }}"

--- a/keyboards/svalboard/azoteq/config.h
+++ b/keyboards/svalboard/azoteq/config.h
@@ -7,8 +7,14 @@
 #define AZOTEQ_IQS5XX_TPS43
 #define AZOTEQ_IQS5XX_TIMEOUT_MS 10
 #define AZOTEQ_IQS5XX_PRESS_AND_HOLD_ENABLE true
-//This decreases the required 'wait' time to activate dragging/selecting on a touchpad from default 300ms to 20ms. Big QoL. 
-#define AZOTEQ_IQS5XX_HOLD_TIME 20
+
+#define AZOTEQ_IQS5XX_TAP_TIME 75
+// TAP_TIME default is 150ms
+#define AZOTEQ_IQS5XX_HOLD_TIME 150 
+// HOLD_TIME default is 300ms
+// Here, we decrease the TAP_TIME to account for the reduced in HOLD_TIME so they aren't confused with each other.
+// HOLD_TIME being reduced from 300ms to 150ms decreases the required 'wait' time to activate dragging/selecting on a touchpad, less sensitive than 20ms, but not tedious like 300ms. 
+
 //#define POINTING_DEVICE_MOTION_PIN GP18
 
 #define SPLIT_POINTING_ENABLE

--- a/keyboards/svalboard/azoteq/config.h
+++ b/keyboards/svalboard/azoteq/config.h
@@ -8,13 +8,6 @@
 #define AZOTEQ_IQS5XX_TIMEOUT_MS 10
 #define AZOTEQ_IQS5XX_PRESS_AND_HOLD_ENABLE true
 
-#define AZOTEQ_IQS5XX_TAP_TIME 75
-// TAP_TIME default is 150ms
-#define AZOTEQ_IQS5XX_HOLD_TIME 150 
-// HOLD_TIME default is 300ms
-// Here, we decrease the TAP_TIME to account for the reduced in HOLD_TIME so they aren't confused with each other.
-// HOLD_TIME being reduced from 300ms to 150ms decreases the required 'wait' time to activate dragging/selecting on a touchpad, less sensitive than 20ms, but not tedious like 300ms. 
-
 //#define POINTING_DEVICE_MOTION_PIN GP18
 
 #define SPLIT_POINTING_ENABLE


### PR DESCRIPTION
This just resets the defaults for Azoteq related config back to their defaults as dictated by QMK firmware's implementation of the drivers,

Specifically, removes the 20ms hold_time for drag (default is 300ms).

PR includes tweak to make build-firmware action work as of 2026-01